### PR TITLE
feat(sweet-nothings): add voice dictation integration

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,6 +170,24 @@
         "type": "github"
       }
     },
+    "flake-utils_5": {
+      "inputs": {
+        "systems": "systems_6"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -508,7 +526,51 @@
         "nixpkgs-master": "nixpkgs-master",
         "nixpkgs-stable": "nixpkgs-stable_2",
         "noctalia": "noctalia",
-        "nvf": "nvf"
+        "nvf": "nvf",
+        "sweet-nothings": "sweet-nothings"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "sweet-nothings",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768445213,
+        "narHash": "sha256-y0BglISgDr61vvdb35m0O4npuqh1pojlBNDILo9j8AI=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "1cd63408e71cc0e6a89ff2cb7c4107214e2523cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "sweet-nothings": {
+      "inputs": {
+        "flake-utils": "flake-utils_5",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1768462241,
+        "narHash": "sha256-TSCfzk8qgYZUaRWwqVSwOvz27P0NF0Nz6Q79BLhU6Eg=",
+        "owner": "jordangarrison",
+        "repo": "sweet-nothings",
+        "rev": "df104e7890dad91bc35d6f2c6d4136197ab033e5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jordangarrison",
+        "repo": "sweet-nothings",
+        "type": "github"
       }
     },
     "systems": {
@@ -572,6 +634,21 @@
       }
     },
     "systems_5": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_6": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -37,11 +37,15 @@
       url = "github:noctalia-dev/noctalia-shell";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    sweet-nothings = {
+      url = "github:jordangarrison/sweet-nothings";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = inputs@{ self, nixpkgs, nixpkgs-stable, nixpkgs-master
     , nixos-hardware, nix-darwin, home-manager, nvf, aws-tools, aws-use-sso
-    , hubctl, claude-code, niri, noctalia, }: {
+    , hubctl, claude-code, niri, noctalia, sweet-nothings, }: {
       nixosConfigurations = {
         "endeavour" = nixpkgs.lib.nixosSystem {
           specialArgs = { inherit inputs; };

--- a/modules/home/niri/default.nix
+++ b/modules/home/niri/default.nix
@@ -18,6 +18,9 @@ in {
     # Noctalia shell (unified bar, notifications, launcher, lock screen, power menu)
     inputs.noctalia.packages.${pkgs.stdenv.hostPlatform.system}.default
 
+    # Sweet Nothings - voice dictation tool
+    inputs.sweet-nothings.packages.${pkgs.stdenv.hostPlatform.system}.default
+
     # File manager (terminal)
     yazi
 
@@ -246,6 +249,12 @@ in {
         matches = [{ app-id = "^nm-connection-editor$"; }];
         open-floating = true;
       }
+      # Float Sweet Nothings dictation window
+      {
+        matches = [{ app-id = "^sweet-nothings$"; }];
+        open-floating = true;
+        default-column-width = { fixed = 400; };
+      }
     ];
 
     # Keybindings (matching Hyprland setup)
@@ -264,6 +273,10 @@ in {
         [ "noctalia-shell" "ipc" "call" "launcher" "toggle" ];
       "Mod+Semicolon".action.spawn =
         [ "noctalia-shell" "ipc" "call" "launcher" "emoji" ];
+
+      # Sweet Nothings - Voice dictation (D for dictation)
+      "Mod+Shift+D".action.spawn =
+        [ "wezterm" "start" "--class" "sweet-nothings" "--" "sweet-nothings" "--paste" ];
 
       # ================
       # WINDOW CONTROLS

--- a/users/jordangarrison/configs/hypr/scripts/niri-keybinds-help.sh
+++ b/users/jordangarrison/configs/hypr/scripts/niri-keybinds-help.sh
@@ -14,6 +14,7 @@ Super + F                 → File manager (Yazi)
 Super + Shift + F         → File manager (Nautilus)
 Super + Space             → App launcher (Noctalia)
 Super + Semicolon         → Emoji picker (rofimoji)
+Super + Shift + D         → Voice dictation (Sweet Nothings)
 
 [WINDOW CONTROLS]
 Super + Q                 → Close window


### PR DESCRIPTION
## Summary

Integrates [sweet-nothings](https://github.com/jordangarrison/sweet-nothings) into the niri desktop configuration as a voice dictation tool.

### What is Sweet Nothings?

Sweet Nothings is a terminal-based dictation tool that:
- Launches via hotkey as a floating popup window
- Immediately begins recording audio when opened
- Transcribes speech locally using whisper when you press Enter
- Copies the transcription to clipboard and auto-pastes it
- Exits automatically after a brief delay

This enables hands-free text input anywhere in the desktop environment - useful for quick notes, messages, or when typing is inconvenient.

### Changes

- **flake.nix**: Added `sweet-nothings` flake input from `github:jordangarrison/sweet-nothings`
- **modules/home/niri/default.nix**: 
  - Added sweet-nothings package
  - Added `Mod+Shift+D` keybinding (D for dictation)
  - Added window rule to open as 400px floating popup
- **niri-keybinds-help.sh**: Added help entry for discoverability

### Affected Hosts

- endeavour (desktop)
- opportunity (Framework laptop)

## Test plan

- [x] `nh os build .` succeeds
- [x] `nh os test .` succeeds  
- [x] Press `Mod+Shift+D` - floating window opens
- [x] Speak and press Enter - transcription copied and pasted
- [x] `Mod+/` shows Sweet Nothings in keybinds help