### PR TITLE
feat: add panko service with cloudflare tunnel

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -192,6 +192,24 @@
         "type": "github"
       }
     },
+    "flake-parts_4": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -621,6 +639,21 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib_2": {
+      "locked": {
+        "lastModified": 1772328832,
+        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "nixpkgs-master": {
       "locked": {
         "lastModified": 1774390575,
@@ -834,6 +867,27 @@
         "type": "github"
       }
     },
+    "panko": {
+      "inputs": {
+        "flake-parts": "flake-parts_4",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775602080,
+        "narHash": "sha256-FzqfNKiR2SYXxm/GmLmnhaOhx72vzNQzNGdx+T0HRNI=",
+        "owner": "jordangarrison",
+        "repo": "panko",
+        "rev": "fda9c415b387323489e0b661e1036ee6a9a7de1c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jordangarrison",
+        "repo": "panko",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "aws-tools": "aws-tools",
@@ -853,6 +907,7 @@
         "nixpkgs-stable": "nixpkgs-stable_2",
         "noctalia": "noctalia",
         "nvf": "nvf",
+        "panko": "panko",
         "sweet-nothings": "sweet-nothings"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,10 @@
       url = "github:jordangarrison/greenlight";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    panko = {
+      url = "github:jordangarrison/panko";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     lakeline-cg = {
       url = "git+ssh://forgejo@forgejo.jordangarrison.dev/jordangarrison/cg.git";
     };
@@ -76,6 +80,7 @@
       sweet-nothings,
       nix-zed-extensions,
       greenlight,
+      panko,
       lakeline-cg,
       grove,
     }:
@@ -104,6 +109,8 @@
             ./modules/nixos/searx.nix
             ./modules/nixos/postgres.nix
             ./modules/nixos/greenlight.nix
+            ./modules/nixos/panko.nix
+            ./modules/nixos/cloudflared.nix
             ./modules/nixos/nginx.nix
             ./modules/nixos/jellyfin.nix
             ./modules/nixos/forgejo.nix
@@ -123,6 +130,7 @@
             home-manager.nixosModules.home-manager
             ./modules/home/defaults.nix
             greenlight.nixosModules.default
+            panko.nixosModules.default
             lakeline-cg.nixosModules.default
             {
               # Configure users for endeavour

--- a/modules/nixos/cloudflared.nix
+++ b/modules/nixos/cloudflared.nix
@@ -1,6 +1,9 @@
-{ config, lib, pkgs, ... }:
+{ ... }:
 
 {
+  # Cloudflare Tunnel for public internet access to panko.
+  # Tunnel created with: cloudflared tunnel create panko
+  # Credentials file must be readable by the cloudflared user (0600, cloudflared:cloudflared).
   services.cloudflared = {
     enable = true;
     tunnels."71e2092b-5e07-4125-8329-f538bdc58d48" = {

--- a/modules/nixos/cloudflared.nix
+++ b/modules/nixos/cloudflared.nix
@@ -1,0 +1,14 @@
+{ config, lib, pkgs, ... }:
+
+{
+  services.cloudflared = {
+    enable = true;
+    tunnels."71e2092b-5e07-4125-8329-f538bdc58d48" = {
+      credentialsFile = "/var/lib/cloudflared/panko.json";
+      default = "http_status:404";
+      ingress = {
+        "panko.jordangarrison.dev" = "http://localhost:4001";
+      };
+    };
+  };
+}

--- a/modules/nixos/panko.nix
+++ b/modules/nixos/panko.nix
@@ -5,7 +5,7 @@
     enable = true;
     host = "panko.jordangarrison.dev";
     port = 4001;
-    listenAddress = "0.0.0.0";
+    listenAddress = "127.0.0.1";
     secretKeyBaseFile = "/var/lib/panko/secrets/secret-key-base";
     tokenSigningSecretFile = "/var/lib/panko/secrets/token-signing-secret";
     database.createLocally = true;
@@ -15,7 +15,9 @@
   };
 
   # Run as jordangarrison so the session watcher can read JSONL files
-  # from ~/.claude/projects and inotifywait resolves correctly
+  # from ~/.claude/projects and inotifywait resolves correctly.
+  # NOTE: This weakens upstream systemd hardening (ProtectHome=false).
+  # Long-term, consider syncing JSONL files to /var/lib/panko/sessions/ instead.
   systemd.services.panko.serviceConfig = {
     User = lib.mkForce "jordangarrison";
     Group = lib.mkForce "users";
@@ -24,6 +26,14 @@
 
   # FileSystem library needs inotifywait at runtime for file watching
   systemd.services.panko.path = [ pkgs.inotify-tools ];
+
+  # Override PHX_SCHEME and PHX_URL_PORT since nginx is configured externally
+  # (services.panko.nginx.enable is false), so the upstream module defaults
+  # to http/4001 instead of https/443.
+  systemd.services.panko.environment = {
+    PHX_SCHEME = lib.mkForce "https";
+    PHX_URL_PORT = lib.mkForce "443";
+  };
 
   # ACME certificate via Cloudflare DNS-01 (defaults from nginx.nix)
   security.acme.certs."panko.jordangarrison.dev" = {
@@ -35,7 +45,7 @@
     forceSSL = true;
     useACMEHost = "panko.jordangarrison.dev";
     locations."/" = {
-      proxyPass = "http://localhost:4001";
+      proxyPass = "http://localhost:${toString config.services.panko.port}";
       proxyWebsockets = true;
     };
   };

--- a/modules/nixos/panko.nix
+++ b/modules/nixos/panko.nix
@@ -1,0 +1,42 @@
+{ config, lib, pkgs, ... }:
+
+{
+  services.panko = {
+    enable = true;
+    host = "panko.jordangarrison.dev";
+    port = 4001;
+    listenAddress = "0.0.0.0";
+    secretKeyBaseFile = "/var/lib/panko/secrets/secret-key-base";
+    tokenSigningSecretFile = "/var/lib/panko/secrets/token-signing-secret";
+    database.createLocally = true;
+    sessionWatchPaths = [
+      "/home/jordangarrison/.claude/projects"
+    ];
+  };
+
+  # Run as jordangarrison so the session watcher can read JSONL files
+  # from ~/.claude/projects and inotifywait resolves correctly
+  systemd.services.panko.serviceConfig = {
+    User = lib.mkForce "jordangarrison";
+    Group = lib.mkForce "users";
+    ProtectHome = lib.mkForce false;
+  };
+
+  # FileSystem library needs inotifywait at runtime for file watching
+  systemd.services.panko.path = [ pkgs.inotify-tools ];
+
+  # ACME certificate via Cloudflare DNS-01 (defaults from nginx.nix)
+  security.acme.certs."panko.jordangarrison.dev" = {
+    group = "nginx";
+  };
+
+  # Nginx reverse proxy
+  services.nginx.virtualHosts."panko.jordangarrison.dev" = {
+    forceSSL = true;
+    useACMEHost = "panko.jordangarrison.dev";
+    locations."/" = {
+      proxyPass = "http://localhost:4001";
+      proxyWebsockets = true;
+    };
+  };
+}


### PR DESCRIPTION
## Summary

- Add Panko (AI coding session viewer) as a flake input and NixOS service on endeavour
- Add Cloudflare Tunnel for public internet access at `panko.jordangarrison.dev`
- Configure nginx reverse proxy with ACME cert for local/Tailscale access

## Details

**Panko service** (`modules/nixos/panko.nix`):
- Port 4001, PostgreSQL with `createLocally`, session file watching on `~/.claude/projects`
- Runs as `jordangarrison` user (needed for home dir access and inotify backend)
- Secrets via systemd LoadCredential at `/var/lib/panko/secrets/`

**Cloudflare Tunnel** (`modules/nixos/cloudflared.nix`):
- Routes `panko.jordangarrison.dev` through Cloudflare's edge network
- Credentials stored at `/var/lib/cloudflared/panko.json`

## Test plan

- [x] `nh os build .` passes
- [x] `nh os test .` activates successfully
- [x] Panko service starts and imports session files
- [x] Public access works via Cloudflare Tunnel
- [x] Nginx reverse proxy works for Tailscale access
- [x] Registration disabled, only admin user can sign in