### PR TITLE
feat: add agent-shell ACP adapters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ result/
 .grove-base
 .grove-start.sh
 .grove-setup.sh
+/.agent-shell/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -426,10 +426,13 @@ home.packages = with pkgs; [
      - `nh os build .`
      - `nh os test .`
      - `nh os switch .`
+       - Confirm with user before running
    - macOS:
      - `nh darwin build .`
      - `nh darwin switch .`
+       - Confirm with user before running
    - Home Manager: `nh home switch .`
+     - Note this is NOT used on systems which use the above
 4. Commit updates: `git add flake.lock && git commit -m "Update flake inputs"`
 
 ### Development Environment

--- a/docs/superpowers/plans/2026-04-24-agent-shell-acp-adapters.md
+++ b/docs/superpowers/plans/2026-04-24-agent-shell-acp-adapters.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add Xenodium `agent-shell` to Doom Emacs with Claude, Codex, and Pi ACP support managed through a reusable, overridable Home Manager ACP adapter module.
 
-**Architecture:** Home Manager owns external ACP adapter binaries through `programs.acp-adapters`; Doom owns Emacs packages, `agent-shell` configuration, and keybindings. The adapter module defaults to `pkgs.llm-agents` packages for Claude and Codex, auto-enables Pi only when `pkgs.llm-agents.pi-acp` exists, and exposes per-adapter package overrides for callers that need a different source.
+**Architecture:** Home Manager owns external ACP adapter binaries through `programs.acp-adapters`; Doom owns Emacs packages, `agent-shell` configuration, and keybindings. The adapter module defaults to `pkgs.llm-agents` packages for Claude and Codex, prefers `pkgs.llm-agents.pi-acp` for Pi when available, falls back to this repository's local `packages/pi-acp`, and exposes per-adapter package overrides for callers that need a different source.
 
 **Tech Stack:** Nix flakes, Home Manager modules, Doom Emacs, Emacs Lisp, `agent-shell`, `acp.el`, `shell-maker`, `pkgs.llm-agents`.
 
@@ -16,7 +16,7 @@
   - Defines `programs.acp-adapters` options.
   - Installs enabled ACP adapter packages into `home.packages`.
   - Defaults Claude to `pkgs.llm-agents.claude-code-acp` and Codex to `pkgs.llm-agents.codex-acp`.
-  - Defaults Pi to `pkgs.llm-agents.pi-acp` only when that attribute exists.
+  - Defaults Pi to `pkgs.llm-agents.pi-acp` when that attribute exists, otherwise to `packages/pi-acp`.
   - Allows each package and command name to be overridden.
   - Fails with a clear assertion when an adapter is enabled without an available package.
 
@@ -267,7 +267,7 @@ add:
   };
 ```
 
-This installs Claude and Codex ACP adapters from `pkgs.llm-agents`. Pi ACP remains auto-disabled until `pkgs.llm-agents.pi-acp` exists or `programs.acp-adapters.pi.package` is explicitly overridden.
+This installs Claude and Codex ACP adapters from `pkgs.llm-agents`. Pi ACP installs from `pkgs.llm-agents.pi-acp` when available, otherwise from the local `packages/pi-acp` fallback.
 
 - [ ] **Step 3: Verify the enabled option evaluates**
 
@@ -307,13 +307,7 @@ Run:
 nix eval '.#homeConfigurations."jordangarrison@normandy".config.programs.acp-adapters.pi.enable'
 ```
 
-Expected output with the current checked `llm-agents` input:
-
-```text
-false
-```
-
-If a future `llm-agents` input exposes `pi-acp`, expected output becomes:
+Expected output:
 
 ```text
 true
@@ -500,12 +494,12 @@ nix eval --raw '.#homeConfigurations."jordangarrison@normandy".config.programs.a
 nix eval '.#homeConfigurations."jordangarrison@normandy".config.programs.acp-adapters.pi.enable'
 ```
 
-Expected output with the current checked `llm-agents` input:
+Expected output:
 
 ```text
 claude-agent-acp
 codex-acp
-false
+true
 ```
 
 - [ ] **Step 3: If switching Home Manager is approved, apply it**
@@ -532,11 +526,7 @@ else
 fi
 ```
 
-Expected output includes paths for `claude-agent-acp` and `codex-acp`. With the current checked `llm-agents` input, expected Pi line is:
-
-```text
-pi-acp not enabled because pkgs.llm-agents.pi-acp is not available
-```
+Expected output includes paths for `claude-agent-acp`, `codex-acp`, and `pi-acp`.
 
 ---
 
@@ -580,7 +570,7 @@ Report these facts to the user:
 agent-shell is configured in Doom Emacs.
 Claude uses claude-agent-acp from pkgs.llm-agents.claude-code-acp.
 Codex uses codex-acp from pkgs.llm-agents.codex-acp.
-Pi agent-shell support is configured and will appear in the picker when pi-acp is installed; the ACP adapter module auto-enables Pi once pkgs.llm-agents.pi-acp exists or when programs.acp-adapters.pi.package is overridden.
+Pi agent-shell support is configured and appears in the picker when pi-acp is installed; the ACP adapter module prefers pkgs.llm-agents.pi-acp and falls back to the local packages/pi-acp package until the llm flake exposes pi-acp.
 ```
 
 ---
@@ -588,6 +578,6 @@ Pi agent-shell support is configured and will appear in the picker when pi-acp i
 ## Self-review checklist
 
 - Spec coverage: This plan implements the reusable ACP adapter module, Doom package declarations, Doom `agent-shell` configuration, leader keybindings, and verification commands. It preserves existing AI tooling by only adding new sections and packages.
-- Package source requirement: Claude and Codex defaults come from `pkgs.llm-agents`; Pi is auto-enabled only if `pkgs.llm-agents.pi-acp` exists, and the module exposes package overrides for all adapters.
+- Package source requirement: Claude and Codex defaults come from `pkgs.llm-agents`; Pi prefers `pkgs.llm-agents.pi-acp` and falls back to local `packages/pi-acp`; the module exposes package overrides for all adapters.
 - Placeholder scan: No implementation step relies on unnamed files, unspecified code, or unresolved command names.
 - Type consistency: Nix option names are consistently `programs.acp-adapters.{claude,codex,pi}.{enable,package,command}`. Emacs command variables match `agent-shell` upstream names from the checked source.

--- a/docs/superpowers/specs/2026-04-24-agent-shell-acp-adapters-design.md
+++ b/docs/superpowers/specs/2026-04-24-agent-shell-acp-adapters-design.md
@@ -118,7 +118,7 @@ Expected package mapping:
 
 - Claude: default to `pkgs.llm-agents.claude-code-acp`, whose main program is `claude-agent-acp`.
 - Codex: default to `pkgs.llm-agents.codex-acp`, whose main program is `codex-acp`.
-- Pi: default to `pkgs.llm-agents.pi-acp` when that package exists. The current checked `llm-agents` input does not expose `pi-acp`, so the module must make this package choice overridable and fail clearly if Pi support is enabled without an available Pi ACP package.
+- Pi: default to `pkgs.llm-agents.pi-acp` when that package exists. The current checked `llm-agents` input does not expose `pi-acp`, so the module uses this repository's local `packages/pi-acp` package as a fallback while keeping `programs.acp-adapters.pi.package` overridable.
 
 ## Doom Emacs design
 
@@ -190,12 +190,12 @@ After implementation:
 ## Risks and mitigations
 
 - **Adapter command name mismatch:** Verify package outputs and configure Doom to use the actual command name or provide a wrapper.
-- **Pi adapter not exposed by `pkgs.llm-agents`:** Keep the Pi package option overridable and fail clearly when Pi support is enabled without a package. Add or override a Pi ACP package later once it is available from the llm flake or a local package.
+- **Pi adapter not exposed by `pkgs.llm-agents`:** Use the local `packages/pi-acp` fallback and keep the Pi package option overridable. Prefer `pkgs.llm-agents.pi-acp` automatically once the llm flake exposes it.
 - **Emacs daemon environment mismatch:** Prefer Nix-managed binaries in user profile and configure environment inheritance for agent processes.
 - **`agent-shell` package/API churn:** Keep configuration minimal and avoid relying on experimental features beyond supported agent configs and command variables.
 - **Overlapping AI tools:** Keep existing `claude-code-ide`, `gptel`, and vterm workflows; `agent-shell` is additive.
 
 ## Open follow-up decisions
 
-- Add Pi ACP support once `pkgs.llm-agents.pi-acp` exists, or set `programs.acp-adapters.pi.package` to an explicit override.
+- Replace the local `packages/pi-acp` fallback with `pkgs.llm-agents.pi-acp` automatically once the llm flake exposes it.
 - Decide later whether `agent-shell` transcripts should stay in project `.agent-shell/` directories or move under Emacs state.

--- a/flake.lock
+++ b/flake.lock
@@ -446,11 +446,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1777019177,
-        "narHash": "sha256-YjPvucTsKmGO9QVNz07x7sSsK11PB0jtMniRkTolbq4=",
+        "lastModified": 1777060931,
+        "narHash": "sha256-V+R+93G4ENClhsfZHUYTcYBkZ8TZeU6X93/IEbOG3Eo=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "8ff0f2a7fcd176b4547da6879ad549de2bbded41",
+        "rev": "59ad447c4551c3b948508bfff472cf20c64ecab0",
         "type": "github"
       },
       "original": {

--- a/modules/home/acp-adapters/default.nix
+++ b/modules/home/acp-adapters/default.nix
@@ -20,6 +20,8 @@ let
 
   llmPackage = name: if builtins.hasAttr name llmAgents then builtins.getAttr name llmAgents else null;
 
+  localPiAcp = pkgs.callPackage ../../../packages/pi-acp { };
+
   adapterPackageOption =
     {
       adapterName,
@@ -102,19 +104,18 @@ in
     pi = {
       enable = mkOption {
         type = types.bool;
-        default = llmPackage "pi-acp" != null;
-        defaultText = literalExpression "pkgs.llm-agents ? pi-acp";
+        default = true;
         description = ''
-          Whether to install the Pi ACP adapter. This defaults to true only when
-          pkgs.llm-agents.pi-acp exists, because the current llm-agents input may
-          not expose a Pi ACP package yet.
+          Whether to install the Pi ACP adapter. The package defaults to
+          pkgs.llm-agents.pi-acp when available, otherwise this repository's
+          local pi-acp package is used as a fallback.
         '';
       };
 
       package = adapterPackageOption {
         adapterName = "Pi";
         llmPackageName = "pi-acp";
-        defaultPackage = llmPackage "pi-acp";
+        defaultPackage = if llmPackage "pi-acp" != null then llmPackage "pi-acp" else localPiAcp;
       };
 
       command = adapterCommandOption {

--- a/modules/home/acp-adapters/default.nix
+++ b/modules/home/acp-adapters/default.nix
@@ -1,0 +1,145 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    literalExpression
+    mkEnableOption
+    mkIf
+    mkOption
+    optional
+    types
+    ;
+
+  cfg = config.programs.acp-adapters;
+  llmAgents = pkgs.llm-agents or { };
+
+  llmPackage = name: if builtins.hasAttr name llmAgents then builtins.getAttr name llmAgents else null;
+
+  adapterPackageOption =
+    {
+      adapterName,
+      llmPackageName,
+      defaultPackage,
+    }:
+    mkOption {
+      type = types.nullOr types.package;
+      default = defaultPackage;
+      defaultText = literalExpression "pkgs.llm-agents.${llmPackageName} or null";
+      description = ''
+        Package providing the ${adapterName} ACP adapter binary. Defaults to
+        pkgs.llm-agents.${llmPackageName} when that package exists, but may be
+        overridden with a nixpkgs package, local package, or future flake output.
+      '';
+    };
+
+  adapterCommandOption =
+    {
+      adapterName,
+      defaultCommand,
+    }:
+    mkOption {
+      type = types.str;
+      default = defaultCommand;
+      description = ''
+        Command name for the ${adapterName} ACP adapter binary. This option is
+        informational for consumers such as Doom Emacs configuration; the module
+        installs packages but does not generate wrappers.
+      '';
+    };
+
+  enabledAdapterPackages =
+    optional (cfg.claude.enable && cfg.claude.package != null) cfg.claude.package
+    ++ optional (cfg.codex.enable && cfg.codex.package != null) cfg.codex.package
+    ++ optional (cfg.pi.enable && cfg.pi.package != null) cfg.pi.package;
+in
+{
+  options.programs.acp-adapters = {
+    enable = mkEnableOption "ACP adapter binaries for agent clients";
+
+    claude = {
+      enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Whether to install the Claude ACP adapter.";
+      };
+
+      package = adapterPackageOption {
+        adapterName = "Claude";
+        llmPackageName = "claude-code-acp";
+        defaultPackage = llmPackage "claude-code-acp";
+      };
+
+      command = adapterCommandOption {
+        adapterName = "Claude";
+        defaultCommand = "claude-agent-acp";
+      };
+    };
+
+    codex = {
+      enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Whether to install the Codex ACP adapter.";
+      };
+
+      package = adapterPackageOption {
+        adapterName = "Codex";
+        llmPackageName = "codex-acp";
+        defaultPackage = llmPackage "codex-acp";
+      };
+
+      command = adapterCommandOption {
+        adapterName = "Codex";
+        defaultCommand = "codex-acp";
+      };
+    };
+
+    pi = {
+      enable = mkOption {
+        type = types.bool;
+        default = llmPackage "pi-acp" != null;
+        defaultText = literalExpression "pkgs.llm-agents ? pi-acp";
+        description = ''
+          Whether to install the Pi ACP adapter. This defaults to true only when
+          pkgs.llm-agents.pi-acp exists, because the current llm-agents input may
+          not expose a Pi ACP package yet.
+        '';
+      };
+
+      package = adapterPackageOption {
+        adapterName = "Pi";
+        llmPackageName = "pi-acp";
+        defaultPackage = llmPackage "pi-acp";
+      };
+
+      command = adapterCommandOption {
+        adapterName = "Pi";
+        defaultCommand = "pi-acp";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !(cfg.claude.enable && cfg.claude.package == null);
+        message = "programs.acp-adapters.claude.enable is true, but no Claude ACP package is available. Set programs.acp-adapters.claude.package or expose pkgs.llm-agents.claude-code-acp.";
+      }
+      {
+        assertion = !(cfg.codex.enable && cfg.codex.package == null);
+        message = "programs.acp-adapters.codex.enable is true, but no Codex ACP package is available. Set programs.acp-adapters.codex.package or expose pkgs.llm-agents.codex-acp.";
+      }
+      {
+        assertion = !(cfg.pi.enable && cfg.pi.package == null);
+        message = "programs.acp-adapters.pi.enable is true, but no Pi ACP package is available. Set programs.acp-adapters.pi.package or expose pkgs.llm-agents.pi-acp.";
+      }
+    ];
+
+    home.packages = enabledAdapterPackages;
+  };
+}

--- a/packages/pi-acp/default.nix
+++ b/packages/pi-acp/default.nix
@@ -1,0 +1,26 @@
+{
+  buildNpmPackage,
+  fetchFromGitHub,
+  lib,
+}:
+
+buildNpmPackage rec {
+  pname = "pi-acp";
+  version = "0.0.26";
+
+  src = fetchFromGitHub {
+    owner = "svkozak";
+    repo = "pi-acp";
+    rev = "v${version}";
+    hash = "sha256-F5uwgWbUmbPcJIk6ylNtxNpKpKI+hFSUWxQ7ffrdUWM=";
+  };
+
+  npmDepsHash = "sha256-vjz+jvHOq/OdT0MSwha5cbAbRXU2jex6ekfOvKnwZsk=";
+
+  meta = {
+    description = "ACP adapter for the Pi coding agent";
+    homepage = "https://github.com/svkozak/pi-acp";
+    license = lib.licenses.mit;
+    mainProgram = "pi-acp";
+  };
+}

--- a/users/jordangarrison/home.nix
+++ b/users/jordangarrison/home.nix
@@ -27,6 +27,7 @@ in
 {
   imports = [
     ./tools/nvim/nvf.nix
+    ../../modules/home/acp-adapters
     ../../modules/home/languages
     ../../modules/home/pi
   ];
@@ -81,6 +82,10 @@ in
   programs.pi = {
     enable = true;
     package = pkgs.llm-agents.pi;
+  };
+
+  programs.acp-adapters = {
+    enable = true;
   };
 
   home.packages =

--- a/users/jordangarrison/tools/doom.d/config.org
+++ b/users/jordangarrison/tools/doom.d/config.org
@@ -561,6 +561,42 @@ Custom functions for managing NixOS configurations directly from Emacs, providin
 (gptel-make-gh-copilot "Copilot")
 #+end_src
 
+** Agent Shell
+Native Emacs shell for ACP-driven coding agents. Adapter binaries are installed through Home Manager's `programs.acp-adapters` module.
+
+#+begin_src emacs-lisp
+(require 'acp)
+(require 'agent-shell)
+
+(after! agent-shell
+  (setq agent-shell-anthropic-authentication
+        (agent-shell-anthropic-make-authentication :login t)
+        agent-shell-openai-authentication
+        (agent-shell-openai-make-authentication :login t)
+        agent-shell-anthropic-claude-acp-command '("claude-agent-acp")
+        agent-shell-openai-codex-acp-command '("codex-acp")
+        agent-shell-pi-acp-command '("pi-acp")
+        agent-shell-anthropic-claude-environment
+        (agent-shell-make-environment-variables :inherit-env t)
+        agent-shell-openai-codex-environment
+        (agent-shell-make-environment-variables :inherit-env t)
+        agent-shell-pi-environment
+        (agent-shell-make-environment-variables :inherit-env t))
+
+  (setq agent-shell-agent-configs
+        (append
+         (list (agent-shell-anthropic-make-claude-code-config)
+               (agent-shell-openai-make-codex-config))
+         (when (executable-find "pi-acp")
+           (list (agent-shell-pi-make-agent-config))))))
+
+(map! :leader
+      :desc "Agent shell" "j a a" #'agent-shell
+      :desc "Agent shell Claude" "j a c" #'agent-shell-anthropic-start-claude-code
+      :desc "Agent shell Codex" "j a x" #'agent-shell-openai-start-codex
+      :desc "Agent shell Pi" "j a p" #'agent-shell-pi-start-agent)
+#+end_src
+
 ** VTerm Integration
 Functions to send code regions to vterm for quick execution.
 

--- a/users/jordangarrison/tools/doom.d/config.org
+++ b/users/jordangarrison/tools/doom.d/config.org
@@ -577,7 +577,9 @@ Native Emacs shell for ACP-driven coding agents. Adapter binaries are installed 
         agent-shell-openai-codex-acp-command '("codex-acp")
         agent-shell-pi-acp-command '("pi-acp")
         agent-shell-anthropic-claude-environment
-        (agent-shell-make-environment-variables :inherit-env t)
+        (agent-shell-make-environment-variables
+         :inherit-env t
+         "CLAUDE_CODE_EXECUTABLE" (or (executable-find "claude") "claude"))
         agent-shell-openai-codex-environment
         (agent-shell-make-environment-variables :inherit-env t)
         agent-shell-pi-environment

--- a/users/jordangarrison/tools/doom.d/config.org
+++ b/users/jordangarrison/tools/doom.d/config.org
@@ -564,12 +564,106 @@ Custom functions for managing NixOS configurations directly from Emacs, providin
 ** Agent Shell
 Native Emacs shell for ACP-driven coding agents. Adapter binaries are installed through Home Manager's `programs.acp-adapters` module.
 
+*** jag/agent-shell-tool-call-summary
+Improve collapsed `agent-shell` tool rows by deriving useful labels from ACP raw input.
+
+#+begin_src emacs-lisp
+(require 'map)
+(require 'seq)
+(require 'subr-x)
+
+(defun jag/agent-shell--map-elt-any (map &rest keys)
+  "Return first non-nil value in MAP for KEYS."
+  (seq-some (lambda (key) (map-elt map key)) keys))
+
+(defun jag/agent-shell--tool-call-command-to-string (command)
+  "Normalize tool-call COMMAND to a display string."
+  (cond
+   ((stringp command) command)
+   ((vectorp command) (combine-and-quote-strings (append command nil)))
+   ((and (listp command) (seq-every-p #'stringp command))
+    (combine-and-quote-strings command))
+   (t nil)))
+
+(defun jag/agent-shell--generic-tool-title-p (title kind)
+  "Return non-nil when TITLE is too generic to be useful.
+
+KIND is the ACP tool kind string, such as read, edit, execute, or other."
+  (let ((normalized-title (and (stringp title) (downcase (string-trim title))))
+        (normalized-kind (and (stringp kind) (downcase (string-trim kind)))))
+    (or (null normalized-title)
+        (string-empty-p normalized-title)
+        (and normalized-kind (string= normalized-title normalized-kind))
+        (member normalized-title
+                '("bash" "edit" "execute" "find" "grep" "ls" "other" "read" "tool" "write")))))
+
+(defun jag/agent-shell-tool-call-summary (tool-call)
+  "Return a concise summary for TOOL-CALL, or nil when its title is already useful.
+
+This uses ACP raw input values so collapsed `agent-shell' tool rows show
+what was executed, not only the generic tool name."
+  (let* ((title (map-elt tool-call :title))
+         (kind (map-elt tool-call :kind))
+         (raw-input (map-elt tool-call :raw-input)))
+    (when (and raw-input (jag/agent-shell--generic-tool-title-p title kind))
+      (let* ((command (jag/agent-shell--tool-call-command-to-string
+                       (jag/agent-shell--map-elt-any raw-input 'command :command)))
+             (path (jag/agent-shell--map-elt-any raw-input
+                                                  'path :path
+                                                  'filepath :filepath
+                                                  'filePath :filePath
+                                                  'fileName :fileName
+                                                  'file_name :file_name
+                                                  'file_path :file_path))
+             (pattern (jag/agent-shell--map-elt-any raw-input
+                                                     'pattern :pattern
+                                                     'query :query
+                                                     'regex :regex))
+             (description (jag/agent-shell--map-elt-any raw-input 'description :description))
+             (summary (cond
+                       ((and command (not (string-empty-p (string-trim command)))) command)
+                       ((and pattern path) (format "%s %s" pattern path))
+                       ((stringp path) path)
+                       ((stringp description) description))))
+        (when (and summary (not (string-empty-p (string-trim summary))))
+          (string-trim (replace-regexp-in-string "[\n\r]+" " " summary)))))))
+#+end_src
+
+*** jag/agent-shell-enable-better-tool-labels
+Install the label summary helper as advice around `agent-shell-make-tool-call-label`.
+
+#+begin_src emacs-lisp
+(defun jag/agent-shell--enhance-tool-call-label (original state tool-call-id)
+  "Advice around ORIGINAL to improve collapsed tool labels.
+
+STATE and TOOL-CALL-ID are passed through to
+`agent-shell-make-tool-call-label'."
+  (let* ((labels (funcall original state tool-call-id))
+         (tool-call (map-nested-elt state `(:tool-calls ,tool-call-id)))
+         (summary (and tool-call (jag/agent-shell-tool-call-summary tool-call))))
+    (when (and labels summary)
+      (setf (map-elt labels :title)
+            (propertize summary 'font-lock-face 'font-lock-doc-markup-face)))
+    labels))
+
+(defun jag/agent-shell-enable-better-tool-labels ()
+  "Enable concise, argument-aware collapsed labels for `agent-shell' tools."
+  (unless (advice-member-p #'jag/agent-shell--enhance-tool-call-label
+                           'agent-shell-make-tool-call-label)
+    (advice-add 'agent-shell-make-tool-call-label
+                :around #'jag/agent-shell--enhance-tool-call-label)))
+#+end_src
+
+*** Agent Shell Configuration
+Configure ACP-backed Claude, Codex, and Pi agents.
+
 #+begin_src emacs-lisp
 (require 'acp)
 (require 'agent-shell)
 
 (after! agent-shell
-  (setq agent-shell-anthropic-authentication
+  (setq agent-shell-thought-process-expand-by-default t
+        agent-shell-anthropic-authentication
         (agent-shell-anthropic-make-authentication :login t)
         agent-shell-openai-authentication
         (agent-shell-openai-make-authentication :login t)
@@ -584,6 +678,8 @@ Native Emacs shell for ACP-driven coding agents. Adapter binaries are installed 
         (agent-shell-make-environment-variables :inherit-env t)
         agent-shell-pi-environment
         (agent-shell-make-environment-variables :inherit-env t))
+
+  (jag/agent-shell-enable-better-tool-labels)
 
   (setq agent-shell-agent-configs
         (append

--- a/users/jordangarrison/tools/doom.d/config.org
+++ b/users/jordangarrison/tools/doom.d/config.org
@@ -12,6 +12,7 @@
   - [[#theme-management][Theme Management]]
   - [[#font-configuration][Font Configuration]]
   - [[#line-numbers-and-visual-elements][Line Numbers and Visual Elements]]
+  - [[#frame-size-configuration][Frame Size Configuration]]
   - [[#dashboard-configuration][Dashboard Configuration]]
 - [[#editor-behavior][Editor Behavior]]
   - [[#shell-prompt-recognition][Shell Prompt Recognition]]
@@ -38,6 +39,7 @@
   - [[#nixos-key-bindings][NixOS Key Bindings]]
 - [[#aillm-integration][AI/LLM Integration]]
   - [[#integration-with-various-ai-and-language-model-services-for-enhanced-development-capabilities][Integration with various AI and language model services for enhanced development capabilities.]]
+  - [[#agent-shell][Agent Shell]]
   - [[#vterm-integration][VTerm Integration]]
   - [[#chatgpt-integration][ChatGPT Integration]]
   - [[#claude-code-ide][Claude Code IDE]]
@@ -629,8 +631,71 @@ what was executed, not only the generic tool name."
           (string-trim (replace-regexp-in-string "[\n\r]+" " " summary)))))))
 #+end_src
 
+#+RESULTS:
+: jag/agent-shell-tool-call-summary
+
+*** jag/agent-shell-tool-call-expanded-by-default-p
+Expand inline edit tool calls, and only expand write tool calls when their payload is small enough to review inline.
+
+#+begin_src emacs-lisp
+(defvar jag/agent-shell-write-tool-auto-expand-max-lines 120
+  "Maximum line count for auto-expanding `agent-shell' write tool calls.")
+
+(defvar jag/agent-shell-write-tool-auto-expand-max-chars 12000
+  "Maximum character count for auto-expanding `agent-shell' write tool calls.")
+
+(defun jag/agent-shell--tool-name-p (tool-call name)
+  "Return non-nil when TOOL-CALL appears to invoke tool NAME."
+  (let ((kind (when-let ((kind (map-elt tool-call :kind)))
+                (downcase (string-trim kind))))
+        (title (when-let ((title (map-elt tool-call :title)))
+                 (downcase (string-trim title)))))
+    (or (equal kind name)
+        (and title
+             (string-match-p
+              (concat "\\(?:\\`\\|[./_-]\\)"
+                      (regexp-quote name)
+                      "\\(?:\\'\\|[[:space:]:(_-]\\)")
+              title)))))
+
+(defun jag/agent-shell--line-count (text)
+  "Return the number of lines in TEXT."
+  (if (string-empty-p text)
+      0
+    (1+ (seq-count (lambda (char) (= char ?\n)) text))))
+
+(defun jag/agent-shell--tool-call-write-content (tool-call)
+  "Return write content from TOOL-CALL raw input, when available."
+  (when-let ((raw-input (map-elt tool-call :raw-input)))
+    (jag/agent-shell--map-elt-any raw-input
+                                  'content :content
+                                  'contents :contents
+                                  'text :text
+                                  'fileContent :fileContent
+                                  'file_content :file_content
+                                  'newContent :newContent
+                                  'new_content :new_content)))
+
+(defun jag/agent-shell--small-write-tool-call-p (tool-call)
+  "Return non-nil when TOOL-CALL is a write with small inline content."
+  (when-let (((jag/agent-shell--tool-name-p tool-call "write"))
+             (content (jag/agent-shell--tool-call-write-content tool-call))
+             ((stringp content)))
+    (and (<= (length content) jag/agent-shell-write-tool-auto-expand-max-chars)
+         (<= (jag/agent-shell--line-count content)
+             jag/agent-shell-write-tool-auto-expand-max-lines))))
+
+(defun jag/agent-shell-tool-call-expanded-by-default-p (tool-call)
+  "Return non-nil when TOOL-CALL should be expanded inline by default."
+  (or (jag/agent-shell--tool-name-p tool-call "edit")
+      (jag/agent-shell--small-write-tool-call-p tool-call)))
+#+end_src
+
+#+RESULTS:
+: jag/agent-shell-tool-call-expanded-by-default-p
+
 *** jag/agent-shell-enable-better-tool-labels
-Install the label summary helper as advice around `agent-shell-make-tool-call-label`.
+Install helpers as advice around `agent-shell' rendering functions.
 
 #+begin_src emacs-lisp
 (defun jag/agent-shell--enhance-tool-call-label (original state tool-call-id)
@@ -646,13 +711,30 @@ STATE and TOOL-CALL-ID are passed through to
             (propertize summary 'font-lock-face 'font-lock-doc-markup-face)))
     labels))
 
+(defun jag/agent-shell--expand-selected-tool-fragments (original &rest args)
+  "Advice around ORIGINAL to expand selected `agent-shell' tool fragments."
+  (let* ((state (plist-get args :state))
+         (block-id (plist-get args :block-id))
+         (tool-call (and state block-id
+                         (map-nested-elt state `(:tool-calls ,block-id)))))
+    (when (and tool-call (jag/agent-shell-tool-call-expanded-by-default-p tool-call))
+      (setq args (plist-put args :expanded t)))
+    (apply original args)))
+
 (defun jag/agent-shell-enable-better-tool-labels ()
-  "Enable concise, argument-aware collapsed labels for `agent-shell' tools."
+  "Enable concise labels and smart expansion for `agent-shell' tools."
   (unless (advice-member-p #'jag/agent-shell--enhance-tool-call-label
                            'agent-shell-make-tool-call-label)
     (advice-add 'agent-shell-make-tool-call-label
-                :around #'jag/agent-shell--enhance-tool-call-label)))
+                :around #'jag/agent-shell--enhance-tool-call-label))
+  (unless (advice-member-p #'jag/agent-shell--expand-selected-tool-fragments
+                           'agent-shell--update-fragment)
+    (advice-add 'agent-shell--update-fragment
+                :around #'jag/agent-shell--expand-selected-tool-fragments)))
 #+end_src
+
+#+RESULTS:
+: jag/agent-shell-enable-better-tool-labels
 
 *** Agent Shell Configuration
 Configure ACP-backed Claude, Codex, and Pi agents.
@@ -688,12 +770,28 @@ Configure ACP-backed Claude, Codex, and Pi agents.
          (when (executable-find "pi-acp")
            (list (agent-shell-pi-make-agent-config))))))
 
+(defun jag/agent-shell-prompt-compose-bottom ()
+  "Open `agent-shell' prompt compose in a bottom side window."
+  (interactive)
+  (let ((agent-shell-display-action
+         '((display-buffer-reuse-window display-buffer-in-side-window)
+           (side . bottom)
+           (slot . 0)
+           (window-height . 0.35)
+           (dedicated . t))))
+    (call-interactively #'agent-shell-prompt-compose)))
+
 (map! :leader
       :desc "Agent shell" "j a a" #'agent-shell
       :desc "Agent shell Claude" "j a c" #'agent-shell-anthropic-start-claude-code
-      :desc "Agent shell Codex" "j a x" #'agent-shell-openai-start-codex
-      :desc "Agent shell Pi" "j a p" #'agent-shell-pi-start-agent)
+      :desc "Agent shell compose prompt" "j a e" #'jag/agent-shell-prompt-compose-bottom
+      :desc "Agent shell Pi" "j a p" #'agent-shell-pi-start-agent
+      :desc "Agent shell queue request" "j a q" #'agent-shell-queue-request
+      :desc "Agent shell Codex" "j a x" #'agent-shell-openai-start-codex)
 #+end_src
+
+#+RESULTS:
+: agent-shell-openai-start-codex
 
 ** VTerm Integration
 Functions to send code regions to vterm for quick execution.

--- a/users/jordangarrison/tools/doom.d/packages.el
+++ b/users/jordangarrison/tools/doom.d/packages.el
@@ -55,6 +55,9 @@
 (package! xclip)
 (package! sqlite3)
 (package! vcl-mode)
+(package! shell-maker)
+(package! acp)
+(package! agent-shell)
 
 ;; Special installs
 (package! git-link


### PR DESCRIPTION
## Summary
- Add a reusable Home Manager `programs.acp-adapters` module for Claude, Codex, and Pi ACP adapter binaries.
- Add Doom Emacs `agent-shell` packages, configuration, and keybindings for Claude/Codex/Pi.
- Add a local `pi-acp` fallback package and update `llm-agents` for newer Claude/Codex ACP adapters.
- Fix Claude agent-shell startup by pointing `CLAUDE_CODE_EXECUTABLE` at the Nix-managed Claude CLI.
- Improve `agent-shell` tool-call rendering with argument-aware collapsed labels.
- Smart-expand inline edit tool calls, while only expanding write calls when payloads are small enough to review inline.

## Motivation / Context
This makes ACP-backed agent sessions in Emacs more usable: tool rows show what actually ran, edits are visible without manual expansion, and large generated writes stay collapsed to avoid flooding the buffer.

## Test Plan
- [x] `doom sync`
- [x] `nh os build . --no-nom`
- [x] `nh os test . --no-nom`
- [x] Verified Emacs sees `claude-agent-acp`, `codex-acp`, `pi-acp`, and agent configs `(claude-code codex pi)`
- [x] Reproduced Claude SDK EPIPE root cause and verified explicit `CLAUDE_CODE_EXECUTABLE` returns `OK`
- [x] `emacs --batch -Q -l /tmp/jag-agent-shell-expand-tests.el` — 5 ERT tests passed for edit/write expansion behavior