### PR TITLE
feat(modules/nixos): add sre-claude-auto-runner on endeavour

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -917,6 +917,7 @@
         "noctalia": "noctalia",
         "nvf": "nvf",
         "panko": "panko",
+        "sre-claude-auto-runner": "sre-claude-auto-runner",
         "sweet-nothings": "sweet-nothings",
         "warp-preview": "warp-preview"
       }
@@ -979,6 +980,26 @@
         "owner": "oxalica",
         "repo": "rust-overlay",
         "type": "github"
+      }
+    },
+    "sre-claude-auto-runner": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778600112,
+        "narHash": "sha256-HNFFR6mdTraqgC8O8AAoCBznGK9ecvNYfPNS2EHnldE=",
+        "ref": "refs/heads/main",
+        "rev": "89ca6f004fc0b198812af7ae3d2fc4ac7e907d58",
+        "revCount": 21,
+        "type": "git",
+        "url": "ssh://forgejo@forgejo.jordangarrison.dev/jordangarrison/sre-claude-auto-runner.git"
+      },
+      "original": {
+        "type": "git",
+        "url": "ssh://forgejo@forgejo.jordangarrison.dev/jordangarrison/sre-claude-auto-runner.git"
       }
     },
     "sweet-nothings": {

--- a/flake.nix
+++ b/flake.nix
@@ -67,6 +67,10 @@
       url = "github:jordangarrison/warp-preview-flake";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    sre-claude-auto-runner = {
+      url = "git+ssh://forgejo@forgejo.jordangarrison.dev/jordangarrison/sre-claude-auto-runner.git";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
@@ -93,6 +97,7 @@
       lakeline-cg,
       grove,
       warp-preview,
+      sre-claude-auto-runner,
     }:
     {
       nixosConfigurations = {
@@ -130,6 +135,7 @@
             ./modules/nixos/freerdp.nix
             ./modules/nixos/blocky.nix
             ./modules/nixos/lakeline-cg.nix
+            ./modules/nixos/sre-claude-auto-runner.nix
             ./users/jordangarrison/nixos.nix
             ./users/mikayla/nixos.nix
             ./users/jane/nixos.nix

--- a/modules/nixos/sre-claude-auto-runner.nix
+++ b/modules/nixos/sre-claude-auto-runner.nix
@@ -1,0 +1,16 @@
+{ inputs, lib, pkgs, ... }:
+
+{
+  imports = [ inputs.sre-claude-auto-runner.nixosModules.default ];
+
+  services.sre-claude-auto-runner = {
+    enable = true;
+    user = "jordangarrison";
+    workspaceDir = "/home/jordangarrison/dev/flocasts";
+    dryRun = false;
+    maxParallel = 1;
+    path = with pkgs; [ claude-code gh jira-cli-go git ];
+  };
+
+  systemd.timers.sre-claude-auto-runner.wantedBy = lib.mkForce [ ];
+}


### PR DESCRIPTION
## Summary
- Wires the new `sre-claude-auto-runner` flake (private, forgejo-hosted) into endeavour as a `services.sre-claude-auto-runner` consumer
- Phase 1 configuration: `dryRun = false`, `maxParallel = 1`, systemd timer disabled (manual invocation only — `systemctl start sre-claude-auto-runner.service`). Timer re-enabled when the runner's design-spec rollout reaches Phase 2 (3 good PRs)
- Module `path` option supplies the operator's CLIs (`claude-code`, `gh`, `jira-cli-go`, `git`) so the systemd unit can find them
- Verified end-to-end with live PR [flocasts/infra-base-services#827](https://github.com/flocasts/infra-base-services/pull/827) for INFRA-6860, SRE Slack handoff posted

## Files
- `flake.nix` — new input `sre-claude-auto-runner` from `git+ssh://forgejo@forgejo.jordangarrison.dev/jordangarrison/sre-claude-auto-runner.git`, follows main `nixpkgs`
- `flake.lock` — pins runner to commit `89ca6f0`
- `modules/nixos/sre-claude-auto-runner.nix` — thin consumer module, mirrored on `emacs.nix` shape

## Test plan
- [x] `nix flake check` clean
- [x] `nh os build .` clean
- [x] `nh os test .` clean — unit + timer installed; timer left disabled per Phase 1 gate
- [x] Manual systemd fire end-to-end against INFRA-6860 — worktree → commit → push → PR → Jira transitions → Slack handoff. Summary written to `/var/lib/sre-claude-auto-runner/runs/<run-id>/summary.md`. Lock cleaned.
- [x] Generation built without timer auto-firing (validated by `wantedBy = lib.mkForce [ ]` override)