### PR TITLE
chore(sre-claude-auto-runner): enable systemd timer (Phase 2)

### DIFF
--- a/modules/nixos/sre-claude-auto-runner.nix
+++ b/modules/nixos/sre-claude-auto-runner.nix
@@ -1,4 +1,4 @@
-{ inputs, lib, pkgs, ... }:
+{ inputs, pkgs, ... }:
 
 {
   imports = [ inputs.sre-claude-auto-runner.nixosModules.default ];
@@ -11,6 +11,4 @@
     maxParallel = 1;
     path = with pkgs; [ claude-code gh jira-cli-go git ];
   };
-
-  systemd.timers.sre-claude-auto-runner.wantedBy = lib.mkForce [ ];
 }


### PR DESCRIPTION
## Summary
- Drops the `wantedBy = lib.mkForce [ ]` override added in #70 — the timer was held off so the Phase 1 gate could be exercised manually.
- PR [flocasts/infra-base-services#827](https://github.com/flocasts/infra-base-services/pull/827) verified the runner end-to-end on INFRA-6860 (pickup → plan → worktree → commit → push → PR → Jira transitions → SRE Slack handoff).
- Timer cadence (per runner module default): Mon–Fri 08–18 America/Chicago, every 15 min, `MAX_PARALLEL=1`.

## Test plan
- [x] `nh os build .` clean
- [x] `nh os test .` clean — `sre-claude-auto-runner.timer` now `active (waiting)` and `enabled`
- [x] Persistent timer catches up the missed slot — observed live fire start immediately on activation