### PR TITLE
feat(nixos): add per-host app flags to reduce closure size

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -158,6 +158,29 @@
                 enable = true;
                 username = "jordangarrison";
                 homeDirectory = "/home/jordangarrison";
+                apps = {
+                  zoom.enable = true;
+                  session-desktop.enable = true;
+                  slack.enable = true;
+                  spotify.enable = true;
+                  discord.enable = true;
+                  signal.enable = true;
+                  obs.enable = true;
+                  obsidian.enable = true;
+                  todoist.enable = true;
+                  calibre.enable = true;
+                  nextcloud.enable = true;
+                  deskflow.enable = true;
+                  freelens.enable = true;
+                  zed.enable = true;
+                  vscode.enable = true;
+                  warp.enable = true;
+                  sidecar.enable = true;
+                  codex.enable = true;
+                  grove.enable = true;
+                  google-cloud-sdk.enable = true;
+                  okta.enable = true;
+                };
               };
 
               users.mikayla = {
@@ -244,12 +267,35 @@
             home-manager.nixosModules.home-manager
             ./modules/home/defaults.nix
             {
-              # Configure users for voyager
+              # Configure users for opportunity
               users.jordangarrison = {
                 enable = true;
                 username = "jordangarrison";
                 homeDirectory = "/home/jordangarrison";
                 swapSuperAlt = true;
+                apps = {
+                  zoom.enable = true;
+                  session-desktop.enable = true;
+                  slack.enable = true;
+                  spotify.enable = true;
+                  discord.enable = true;
+                  signal.enable = true;
+                  obs.enable = true;
+                  obsidian.enable = true;
+                  todoist.enable = true;
+                  calibre.enable = true;
+                  nextcloud.enable = true;
+                  deskflow.enable = true;
+                  freelens.enable = true;
+                  zed.enable = true;
+                  vscode.enable = true;
+                  warp.enable = true;
+                  sidecar.enable = true;
+                  codex.enable = true;
+                  grove.enable = true;
+                  google-cloud-sdk.enable = true;
+                  okta.enable = true;
+                };
               };
 
               users.mikayla = {

--- a/users/jordangarrison/home-linux.nix
+++ b/users/jordangarrison/home-linux.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, username, homeDirectory, inputs, swapSuperAlt ? false, ... }:
+{ config, pkgs, lib, username, homeDirectory, inputs, swapSuperAlt ? false, userApps ? {}, ... }:
 
 {
   imports = [
@@ -8,10 +8,11 @@
     ../../modules/home/ghostty/apps.nix
     ../../modules/home/wezterm  # Keep for SSH apps only
     ../../modules/home/virt-manager/config.nix
+  ] ++ lib.optionals (userApps.zed.enable or false) [
     ../../modules/home/zed-editor
   ];
 
-  home.packages = [
+  home.packages = lib.optionals (userApps.warp.enable or false) [
     inputs.warp-preview.packages.${pkgs.system}.default
   ];
 

--- a/users/jordangarrison/home.nix
+++ b/users/jordangarrison/home.nix
@@ -5,6 +5,7 @@
   username,
   homeDirectory,
   inputs,
+  userApps ? {},
   ...
 }:
 
@@ -98,8 +99,6 @@ in
 
       # LLM Agents (available via overlay as pkgs.llm-agents.*)
       llm-agents.claude-code
-      llm-agents.codex
-      llm-agents.opencode
       sox # Audio playback/recording, used by Claude Code
       otel-tui # Terminal OpenTelemetry viewer
 
@@ -113,17 +112,10 @@ in
       ksn # kubectl namespace switcher
       claude-switch # Claude Code credential profile switcher
 
-      # Okta CLI
-      okta-cli-client
-
-      # Sidecar - TUI companion for CLI coding agents
-      sidecar
       td
 
       # Apps
       arandr
-      spotify
-      todoist
       wezterm
       # doom-emacs
 
@@ -213,16 +205,29 @@ in
       inputs.aws-tools.packages.${pkgs.stdenv.hostPlatform.system}.default
       inputs.aws-use-sso.packages.${pkgs.stdenv.hostPlatform.system}.default
 
-      # Grove - workspace manager
-      inputs.grove.packages.${pkgs.stdenv.hostPlatform.system}.default
-
       # Google Workspace CLI
       gws
-
-      # GCP - using stable due to tkinter dependency issue in unstable
+    ]
+    ++ lib.optionals (userApps.grove.enable or false) [
+      inputs.grove.packages.${pkgs.stdenv.hostPlatform.system}.default
+    ]
+    ++ lib.optionals (userApps.google-cloud-sdk.enable or false) [
       (stable.google-cloud-sdk.withExtraComponents [
         stable.google-cloud-sdk.components.gke-gcloud-auth-plugin
       ])
+    ]
+    ++ lib.optionals (userApps.sidecar.enable or false) [
+      sidecar
+    ]
+    ++ lib.optionals (userApps.okta.enable or false) [
+      okta-cli-client
+    ]
+    ++ lib.optionals (userApps.codex.enable or false) [
+      llm-agents.codex
+      llm-agents.opencode
+    ]
+    ++ lib.optionals (userApps.todoist.enable or false) [
+      todoist
     ]
     ++ (
       if pkgs.stdenv.isDarwin then
@@ -234,30 +239,16 @@ in
           aws-sso-cli
           bibletime
           comixcursors
-          discord
-          # Signal Desktop wrapped to use gnome-keyring for secrets storage
-          (pkgs.symlinkJoin {
-            name = "signal-desktop";
-            paths = [ pkgs.signal-desktop ];
-            buildInputs = [ pkgs.makeWrapper ];
-            postBuild = ''
-              wrapProgram $out/bin/signal-desktop \
-                --add-flags "--password-store=gnome-libsecret"
-            '';
-          })
           deno
           dig
           # emacs
           emacsPackages.sqlite3
-          freelens-bin
           glibc
           gnaural
           grip
-          obs-studio
           pavucontrol
           pinentry-gnome3
           remmina
-          stable.slack
           vial
           wally-cli
           xcb-util-cursor
@@ -267,7 +258,33 @@ in
           inputs.hubctl.packages.${pkgs.stdenv.hostPlatform.system}.default
           ghostty
         ]
-    );
+    )
+    ++ lib.optionals ((userApps.discord.enable or false) && pkgs.stdenv.isLinux) [
+      discord
+    ]
+    ++ lib.optionals ((userApps.signal.enable or false) && pkgs.stdenv.isLinux) [
+      (pkgs.symlinkJoin {
+        name = "signal-desktop";
+        paths = [ pkgs.signal-desktop ];
+        buildInputs = [ pkgs.makeWrapper ];
+        postBuild = ''
+          wrapProgram $out/bin/signal-desktop \
+            --add-flags "--password-store=gnome-libsecret"
+        '';
+      })
+    ]
+    ++ lib.optionals ((userApps.obs.enable or false) && pkgs.stdenv.isLinux) [
+      obs-studio
+    ]
+    ++ lib.optionals (userApps.spotify.enable or false) [
+      spotify
+    ]
+    ++ lib.optionals (userApps.slack.enable or false) [
+      stable.slack
+    ]
+    ++ lib.optionals (userApps.freelens.enable or false) [
+      freelens-bin
+    ];
 
   programs.gpg = {
     enable = pkgs.stdenv.isLinux;
@@ -453,7 +470,7 @@ in
   };
 
   programs.vscode = {
-    enable = true;
+    enable = userApps.vscode.enable or false;
     # package = pkgs.code-cursor;
   };
 

--- a/users/jordangarrison/nixos.nix
+++ b/users/jordangarrison/nixos.nix
@@ -22,6 +22,37 @@ in {
       default = false;
       description = "Swap Super and Alt keys in GNOME";
     };
+
+    apps = {
+      # Communication
+      zoom.enable = lib.mkEnableOption "Zoom video conferencing";
+      session-desktop.enable = lib.mkEnableOption "Session encrypted messenger";
+      slack.enable = lib.mkEnableOption "Slack messaging";
+      discord.enable = lib.mkEnableOption "Discord";
+      signal.enable = lib.mkEnableOption "Signal messenger";
+
+      # Media & productivity
+      spotify.enable = lib.mkEnableOption "Spotify music";
+      obs.enable = lib.mkEnableOption "OBS Studio";
+      obsidian.enable = lib.mkEnableOption "Obsidian and Logseq note-taking";
+      todoist.enable = lib.mkEnableOption "Todoist task manager";
+      calibre.enable = lib.mkEnableOption "Calibre e-book manager";
+      nextcloud.enable = lib.mkEnableOption "Nextcloud client";
+      deskflow.enable = lib.mkEnableOption "Deskflow KVM";
+
+      # Editors & terminals
+      zed.enable = lib.mkEnableOption "Zed editor";
+      vscode.enable = lib.mkEnableOption "VSCode / Cursor editor";
+      warp.enable = lib.mkEnableOption "Warp terminal (preview)";
+
+      # Dev tools (heavy, built from source)
+      freelens.enable = lib.mkEnableOption "Freelens Kubernetes IDE";
+      sidecar.enable = lib.mkEnableOption "Sidecar TUI for coding agents";
+      codex.enable = lib.mkEnableOption "Codex and OpenCode LLM agents";
+      grove.enable = lib.mkEnableOption "Grove workspace manager";
+      google-cloud-sdk.enable = lib.mkEnableOption "Google Cloud SDK";
+      okta.enable = lib.mkEnableOption "Okta CLI client";
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -32,11 +63,19 @@ in {
       shell = pkgs.zsh;
       home = cfg.homeDirectory;
       packages = with pkgs; [
-        stable.calibre # Broken in nix-unstable - Qt6 GuiPrivate component missing
+        xournalpp
+      ] ++ lib.optionals cfg.apps.calibre.enable [
+        stable.calibre
+      ] ++ lib.optionals cfg.apps.deskflow.enable [
         deskflow
-        stable.nextcloud-client # Broken in nix-unstable - Qt6 GuiPrivate component missing
+      ] ++ lib.optionals cfg.apps.nextcloud.enable [
+        stable.nextcloud-client
+      ] ++ lib.optionals cfg.apps.obsidian.enable [
         obsidian
         logseq
+      ] ++ lib.optionals cfg.apps.todoist.enable [
+        todoist-electron
+      ] ++ lib.optionals cfg.apps.session-desktop.enable [
         # session-desktop: clear executable stack flag on better-sqlite3
         # glibc 2.41+ rejects dlopen of shared libraries with RWE GNU_STACK
         # https://github.com/NixOS/nixpkgs/issues/487524
@@ -49,8 +88,7 @@ in {
             done
           '';
         }))
-        todoist-electron
-        xournalpp
+      ] ++ lib.optionals cfg.apps.zoom.enable [
         zoom-us
       ];
     };
@@ -77,6 +115,7 @@ in {
       username = cfg.username;
       homeDirectory = cfg.homeDirectory;
       swapSuperAlt = cfg.swapSuperAlt;
+      userApps = cfg.apps;
     };
   };
 }


### PR DESCRIPTION
## Summary

- Adds 21 `users.jordangarrison.apps.<name>.enable` options (all default `false`) for heavy desktop apps and dev tools
- Endeavour and opportunity opt in to all apps; discovery and voyager use lean defaults
- Reduces discovery's system closure from **28.9 GiB to 18.9 GiB** (-10 GB)

### Flagged apps

| Category | Apps |
|---|---|
| Communication | zoom, session-desktop, slack, discord, signal |
| Media & productivity | spotify, obs, obsidian (+ logseq), todoist, calibre, nextcloud, deskflow |
| Editors & terminals | zed, vscode, warp |
| Dev tools (heavy builds) | freelens, sidecar, codex (+ opencode), grove, google-cloud-sdk, okta |

### Per-host configuration

| Host | Apps |
|---|---|
| endeavour | all enabled |
| opportunity | all enabled |
| voyager | none (defaults) |
| discovery | none (defaults) |

Closes #73

## Test plan

- [x] `nh os build .` succeeds for discovery
- [x] `nh os test .` activates cleanly on discovery
- [x] `nh os switch .` applied and in bootloader
- [ ] Verify endeavour and opportunity builds still work (no changes to their closure contents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)