### PR TITLE
feat(packages): add readwise-cli for all hosts

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -111,6 +111,7 @@
             ./modules/scripts-overlay.nix
             ./modules/llm-agents-overlay.nix
             ./modules/okta-cli-client-overlay.nix
+            ./modules/readwise-cli-overlay.nix
             ./modules/sidecar-overlay.nix
             ./modules/brave-overlay.nix
             ./modules/tea-overlay.nix
@@ -244,6 +245,7 @@
             ./modules/scripts-overlay.nix
             ./modules/llm-agents-overlay.nix
             ./modules/okta-cli-client-overlay.nix
+            ./modules/readwise-cli-overlay.nix
             ./modules/sidecar-overlay.nix
             ./modules/brave-overlay.nix
             ./modules/nixos/common.nix
@@ -341,6 +343,7 @@
             ./modules/scripts-overlay.nix
             ./modules/llm-agents-overlay.nix
             ./modules/okta-cli-client-overlay.nix
+            ./modules/readwise-cli-overlay.nix
             ./modules/sidecar-overlay.nix
             ./modules/brave-overlay.nix
             ./modules/nixos/common.nix
@@ -396,6 +399,7 @@
             ./modules/scripts-overlay.nix
             ./modules/llm-agents-overlay.nix
             ./modules/okta-cli-client-overlay.nix
+            ./modules/readwise-cli-overlay.nix
             ./modules/sidecar-overlay.nix
             ./modules/brave-overlay.nix
             ./modules/nixos/common.nix
@@ -451,6 +455,7 @@
             ./modules/scripts-overlay.nix
             ./modules/llm-agents-overlay.nix
             ./modules/okta-cli-client-overlay.nix
+            ./modules/readwise-cli-overlay.nix
             ./modules/sidecar-overlay.nix
             ./modules/nixos/emacs.nix
             ./modules/nixos/fonts.nix
@@ -490,6 +495,7 @@
             ./modules/scripts-overlay.nix
             ./modules/llm-agents-overlay.nix
             ./modules/okta-cli-client-overlay.nix
+            ./modules/readwise-cli-overlay.nix
             ./modules/sidecar-overlay.nix
             ./modules/brave-overlay.nix
             ./users/jordangarrison/home.nix

--- a/modules/readwise-cli-overlay.nix
+++ b/modules/readwise-cli-overlay.nix
@@ -1,0 +1,9 @@
+{ ... }:
+
+{
+  nixpkgs.overlays = [
+    (final: prev: {
+      readwise-cli = final.callPackage ../packages/readwise-cli { };
+    })
+  ];
+}

--- a/packages/readwise-cli/default.nix
+++ b/packages/readwise-cli/default.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage rec {
+  pname = "readwise-cli";
+  version = "0.5.6";
+
+  src = fetchFromGitHub {
+    owner = "readwiseio";
+    repo = "readwise-cli";
+    rev = "v${version}";
+    hash = "sha256-mRAhGETEoAoqVnVne4PuGVRMjZEBIz8m8WVcA0HtfGQ=";
+  };
+
+  npmDepsHash = "sha256-eupjqOEE77pNzY9DBJdYdDraJtUVhbojaG/QCW+m+jw=";
+
+  meta = {
+    description = "Official command-line interface for Readwise and Reader";
+    homepage = "https://github.com/readwiseio/readwise-cli";
+    license = lib.licenses.mit;
+    mainProgram = "readwise";
+    maintainers = [ ];
+  };
+}

--- a/users/jordangarrison/home.nix
+++ b/users/jordangarrison/home.nix
@@ -113,6 +113,7 @@ in
       claude-switch # Claude Code credential profile switcher
 
       td
+      readwise-cli # Readwise & Reader CLI
 
       # Apps
       arandr


### PR DESCRIPTION
## Summary
- Package the official `@readwise/cli` ([readwiseio/readwise-cli](https://github.com/readwiseio/readwise-cli)) v0.5.6 as `pkgs.readwise-cli` via `buildNpmPackage`.
- Expose it on every NixOS/Darwin host through a new `modules/readwise-cli-overlay.nix` (mirrors the `okta-cli-client-overlay` pattern).
- Add it to `jordangarrison`'s unconditional `home.packages` so it lands on every machine.

## Test plan
- [x] `nix-build` of `packages/readwise-cli/default.nix` succeeds.
- [x] `./result/bin/readwise --version` reports `0.5.6`.
- [x] `nh os build .` succeeds on `endeavour` and the diff adds `readwise-cli 0.5.6` (+15.3 MiB).
- [x] `nh os test .` activates cleanly; `readwise --help`, `readwise config show`, and `readwise skills list` all work.
- [ ] `readwise login` happy path (requires interactive browser flow, not run in CI).