### PR TITLE
feat(home): add agent-browser CLI for AI agent browser automation

### DIFF
--- a/users/jordangarrison/home.nix
+++ b/users/jordangarrison/home.nix
@@ -99,6 +99,7 @@ in
 
       # LLM Agents (available via overlay as pkgs.llm-agents.*)
       llm-agents.claude-code
+      llm-agents.agent-browser # Headless browser automation CLI for AI agents
       sox # Audio playback/recording, used by Claude Code
       otel-tui # Terminal OpenTelemetry viewer
 


### PR DESCRIPTION
## Summary
- Adds `llm-agents.agent-browser` (vercel-labs/agent-browser, v0.27.0) to `users/jordangarrison/home.nix` alongside `llm-agents.claude-code`.
- Headless browser automation CLI designed for AI agents — supports `snapshot` (accessibility tree with refs), `click @e2`, `eval`, `screenshot`, semantic locators (`find role button --name "Submit"`), and a `chat` REPL.
- The llm-agents wrapper bakes in a Nix-provided chromium 148 (`AGENT_BROWSER_EXECUTABLE_PATH`), so the upstream `agent-browser install` step is **not** needed.
- Long-term, this is intended to replace the claude-in-chrome MCP for ad-hoc agent web tasks.

## Test plan
- [x] `nh os build . --no-nom` — clean (1.48 GiB closure growth, mostly chromium)
- [x] `nh os test . --no-nom` — activated on endeavour
- [x] `agent-browser open https://example.com` + `snapshot` + `click @e2` + `eval` + `screenshot` + `close --all` — all working
- [ ] `nh os switch . --no-nom` after merge