### PR TITLE
feat(packages): add varlock CLI for .env schema management

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -112,6 +112,7 @@
             ./modules/llm-agents-overlay.nix
             ./modules/okta-cli-client-overlay.nix
             ./modules/readwise-cli-overlay.nix
+            ./modules/varlock-overlay.nix
             ./modules/sidecar-overlay.nix
             ./modules/brave-overlay.nix
             ./modules/tea-overlay.nix
@@ -246,6 +247,7 @@
             ./modules/llm-agents-overlay.nix
             ./modules/okta-cli-client-overlay.nix
             ./modules/readwise-cli-overlay.nix
+            ./modules/varlock-overlay.nix
             ./modules/sidecar-overlay.nix
             ./modules/brave-overlay.nix
             ./modules/nixos/common.nix
@@ -344,6 +346,7 @@
             ./modules/llm-agents-overlay.nix
             ./modules/okta-cli-client-overlay.nix
             ./modules/readwise-cli-overlay.nix
+            ./modules/varlock-overlay.nix
             ./modules/sidecar-overlay.nix
             ./modules/brave-overlay.nix
             ./modules/nixos/common.nix
@@ -400,6 +403,7 @@
             ./modules/llm-agents-overlay.nix
             ./modules/okta-cli-client-overlay.nix
             ./modules/readwise-cli-overlay.nix
+            ./modules/varlock-overlay.nix
             ./modules/sidecar-overlay.nix
             ./modules/brave-overlay.nix
             ./modules/nixos/common.nix
@@ -456,6 +460,7 @@
             ./modules/llm-agents-overlay.nix
             ./modules/okta-cli-client-overlay.nix
             ./modules/readwise-cli-overlay.nix
+            ./modules/varlock-overlay.nix
             ./modules/sidecar-overlay.nix
             ./modules/nixos/emacs.nix
             ./modules/nixos/fonts.nix
@@ -496,6 +501,7 @@
             ./modules/llm-agents-overlay.nix
             ./modules/okta-cli-client-overlay.nix
             ./modules/readwise-cli-overlay.nix
+            ./modules/varlock-overlay.nix
             ./modules/sidecar-overlay.nix
             ./modules/brave-overlay.nix
             ./users/jordangarrison/home.nix

--- a/modules/varlock-overlay.nix
+++ b/modules/varlock-overlay.nix
@@ -1,0 +1,9 @@
+{ ... }:
+
+{
+  nixpkgs.overlays = [
+    (final: prev: {
+      varlock = final.callPackage ../packages/varlock { };
+    })
+  ];
+}

--- a/packages/varlock/default.nix
+++ b/packages/varlock/default.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  nodejs_22,
+  makeWrapper,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "varlock";
+  version = "1.2.0";
+
+  src = fetchurl {
+    url = "https://registry.npmjs.org/varlock/-/varlock-${finalAttrs.version}.tgz";
+    hash = "sha256-XAR5zYmQ/00T7DFZmbD8EzOyR12OsEe7mfKeDnZZV84=";
+  };
+
+  sourceRoot = "package";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/varlock $out/bin
+    cp -r bin dist package.json $out/lib/varlock/
+    if [ -d native-bins ]; then
+      cp -r native-bins $out/lib/varlock/
+    fi
+
+    makeWrapper ${nodejs_22}/bin/node $out/bin/varlock \
+      --add-flags $out/lib/varlock/bin/cli.js
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/bin/varlock --version | grep -F "${finalAttrs.version}"
+    runHook postInstallCheck
+  '';
+
+  meta = {
+    description = "AI-safe .env files: schemas for agents, secrets for humans";
+    homepage = "https://varlock.dev";
+    license = lib.licenses.mit;
+    mainProgram = "varlock";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+  };
+})

--- a/users/jordangarrison/home.nix
+++ b/users/jordangarrison/home.nix
@@ -115,6 +115,7 @@ in
 
       td
       readwise-cli # Readwise & Reader CLI
+      varlock # AI-safe .env files: schemas for agents, secrets for humans
 
       # Apps
       arandr


### PR DESCRIPTION
## Summary
- Adds `varlock` (1.2.0) as a custom package wrapping the upstream npm tarball with Node 22
- Bundled native encryption helpers (statically-linked Rust PIE) ride along untouched — full feature parity with the standalone binary
- Exposed via overlay across all hosts (endeavour, opportunity, voyager, discovery, H952L3DPHH); installed in jordangarrison's home packages

## Background
Evaluated three approaches with a multi-agent panel (local pkg, standalone flake, fork+upstream); panel converged unanimously on the local-package approach after verifying (a) the npm tarball ships the same native helpers as the prebuilt binary, and (b) the daily \`update-flake-lock\` bot would not actually bump a separately-hosted flake's internal version pin.

## Test plan
- [x] Standalone build: \`nix-build -E 'with import <nixpkgs> {}; callPackage ./packages/varlock {}'\`
- [x] \`--version\` returns 1.2.0; \`--help\` lists all 14 subcommands; \`varlock scan\` runs cleanly
- [x] Overlay resolves to varlock 1.2.0 on all 4 NixOS hosts + Darwin host
- [x] Full \`nh os build .\` for endeavour succeeds — diff adds \`varlock 1.2.0\` (5.27 MiB)
- [x] \`nh os test .\` confirmed working on endeavour
- [ ] Merge → \`nh os switch .\`