### PR TITLE
feat(herdr): declarative session persistence + Nix live-handoff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -806,6 +806,16 @@ settings in `users/jordangarrison/home.nix` and rebuild, not in the herdr UI.
 conversations survive a server restart (runtime state lives in the unmanaged
 `session.json` / `session-history.json`).
 
+**Agent integrations:** `resume_agents_on_restore` only works when the per-agent herdr
+hook is current (e.g. Claude Code needs integration v4+). These hooks live in mutable
+dotfiles (`~/.claude/hooks/`, `~/.codex/`, …) and herdr bumps their version on every
+release, so they silently drift and break resume after a herdr update. The
+`programs.herdr.integrations` option (`["claude" "codex" "pi" "opencode"]`) re-runs
+`herdr integration install <agent>` on every activation to keep them in sync. Two
+caveats: `pane_history` is startup-only (a server already running when it is first
+enabled captures nothing — the *next* restart begins capturing), and resume only works
+for agent panes that ran under the current hook before the restart.
+
 **Update workflow (keep live processes across a herdr bump):**
 `herdr update --handoff` does not work on Nix (its downloader can't write to
 `/nix/store`). Instead:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -797,6 +797,25 @@ nvf-print-config-path
 - Doom-style keybindings for familiar editing
 - SSH configuration for remote development
 
+### herdr session persistence
+
+herdr config is managed declaratively by `programs.herdr` (`modules/home/herdr/`),
+gated on `userApps.herdr.enable`. `config.toml` is a read-only Nix symlink — change
+settings in `users/jordangarrison/home.nix` and rebuild, not in the herdr UI.
+`pane_history` and `resume_agents_on_restore` are enabled, so scrollback and agent
+conversations survive a server restart (runtime state lives in the unmanaged
+`session.json` / `session-history.json`).
+
+**Update workflow (keep live processes across a herdr bump):**
+`herdr update --handoff` does not work on Nix (its downloader can't write to
+`/nix/store`). Instead:
+1. `nh flake update llm-agents` then `nh os switch . --no-nom`
+2. `herdr-handoff`  — migrates the running session onto the new store-path binary
+   via `herdr server live-handoff --import-exe`, keeping pane processes alive.
+If herdr refuses the handoff (incompatible protocol across versions), restart the
+server normally; `pane_history` + `resume_agents_on_restore` restore scrollback and
+agent conversations.
+
 ## Documentation Structure
 
 The `docs/` directory contains project documentation:

--- a/docs/superpowers/plans/2026-05-28-herdr-session-persistence.md
+++ b/docs/superpowers/plans/2026-05-28-herdr-session-persistence.md
@@ -1,0 +1,364 @@
+# herdr Session Persistence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make herdr survive walk-aways and version updates without losing session context, by enabling its persistence knobs declaratively, managing `config.toml` via a new home-manager module, and shipping a Nix-compatible live-handoff helper.
+
+**Architecture:** A new `programs.herdr` home-manager module (modeled on the existing `programs.tea` / `programs.pi` modules) owns herdr's `config.toml`, writing it from a TOML settings attrset and installing the herdr package. A small `herdr-handoff` script package wraps `herdr server live-handoff --import-exe`, which is the only Nix-viable way to keep live pane processes alive across a herdr binary swap (the bundled `herdr update` downloader can't write to `/nix/store`). The existing per-host `userApps.herdr.enable` switch drives the module.
+
+**Tech Stack:** Nix, home-manager, `pkgs.formats.toml`, `lib/mkScript.nix`, herdr 0.6.4 (`pkgs.llm-agents.herdr`).
+
+**Reference spec:** `docs/superpowers/specs/2026-05-28-herdr-session-persistence-design.md`
+
+**Branch:** `feat/herdr-session-persistence` (already created; the design doc is committed there).
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `packages/herdr-handoff/herdr-handoff.sh` | Wrapper: trigger live-handoff against the current store-path binary | Create |
+| `modules/scripts-overlay.nix` | Register `pkgs.herdr-handoff` via `mkScript` | Modify (add one entry) |
+| `modules/home/herdr/default.nix` | `programs.herdr` option surface; writes `config.toml`; installs herdr + helper | Create |
+| `users/jordangarrison/home.nix` | Import the module, map `userApps.herdr.enable` → `programs.herdr.enable`, drop the now-redundant package entry | Modify |
+
+**Verification note (Nix, not unit tests):** There is no test runner here. "Verify it fails / passes" means running `nh os build . --no-nom` (validates module evaluation + TOML generation for the whole system) and inspecting generated files. Per repo convention and CLAUDE.md, **`--no-nom` is mandatory** on every `nh` call. Use `nh os test . --no-nom` to apply to the running system for runtime checks; only `nh os switch` when the whole plan is verified, and only after confirming with the user.
+
+---
+
+### Task 1: Create the `herdr-handoff` helper script package
+
+**Files:**
+- Create: `packages/herdr-handoff/herdr-handoff.sh`
+- Modify: `modules/scripts-overlay.nix` (add entry before the closing `})` of the overlay)
+
+- [ ] **Step 1: Write the wrapper script**
+
+Create `packages/herdr-handoff/herdr-handoff.sh`:
+
+```bash
+#!/usr/bin/env bash
+# herdr-handoff — migrate the running herdr session onto the current binary,
+# keeping live pane processes alive. The Nix-viable alternative to
+# `herdr update --handoff` (whose downloader can't write to /nix/store).
+#
+# Usage: after `nh os switch`, run `herdr-handoff` to hand the running
+# server's live panes to the freshly-built herdr binary.
+set -euo pipefail
+
+new_exe="$(readlink -f "$(command -v herdr)")"
+echo "herdr-handoff: handing off live panes to ${new_exe}"
+echo "herdr-handoff: if the protocol is incompatible, herdr will refuse and you should restart instead."
+exec herdr server live-handoff --import-exe "${new_exe}"
+```
+
+- [ ] **Step 2: Register the package in the scripts overlay**
+
+In `modules/scripts-overlay.nix`, add this entry immediately after the `flarectl-wrapped` block (the last entry, just before the closing `})`):
+
+```nix
+      herdr-handoff = mkScript {
+        name = "herdr-handoff";
+        script = ../packages/herdr-handoff/herdr-handoff.sh;
+        deps = with final; [ coreutils ];
+        description = "Migrate the running herdr session onto the current binary via live-handoff";
+      };
+```
+
+- [ ] **Step 3: Verify the package builds**
+
+Run: `nix build .#nixosConfigurations.opportunity.pkgs.herdr-handoff --no-link --print-out-paths 2>&1 | tail -5`
+Expected: prints a `/nix/store/...-herdr-handoff` path with no evaluation errors.
+
+(If that attribute path is not exposed, instead verify via the full build in Step 4 of Task 4; the overlay entry alone cannot break unrelated evaluation.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/herdr-handoff/herdr-handoff.sh modules/scripts-overlay.nix
+git commit -m "feat(herdr): add herdr-handoff live-handoff helper package"
+```
+
+---
+
+### Task 2: Create the `programs.herdr` home-manager module
+
+**Files:**
+- Create: `modules/home/herdr/default.nix`
+
+- [ ] **Step 1: Write the module**
+
+Create `modules/home/herdr/default.nix`:
+
+```nix
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+
+let
+  cfg = config.programs.herdr;
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  options.programs.herdr = {
+    enable = mkEnableOption "herdr terminal workspace manager for AI coding agents";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.llm-agents.herdr;
+      defaultText = literalExpression "pkgs.llm-agents.herdr";
+      description = "The herdr package to install.";
+    };
+
+    settings = mkOption {
+      type = tomlFormat.type;
+      default = { };
+      example = literalExpression ''
+        {
+          onboarding = false;
+          theme.name = "rose-pine";
+          experimental.pane_history = true;
+          session.resume_agents_on_restore = true;
+        }
+      '';
+      description = ''
+        Settings written to {file}`$XDG_CONFIG_HOME/herdr/config.toml`.
+
+        Because Nix manages this file it becomes a read-only symlink: change
+        settings here and rebuild rather than editing them in the herdr UI.
+        herdr's mutable runtime state (session.json, session-history.json,
+        logs, sockets, release-notes.json) is intentionally not managed and
+        stays writable.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [
+      cfg.package
+      pkgs.herdr-handoff
+    ];
+
+    xdg.configFile."herdr/config.toml" = mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "herdr-config.toml" cfg.settings;
+    };
+  };
+}
+```
+
+- [ ] **Step 2: Verify the module file parses**
+
+Run: `nix-instantiate --parse modules/home/herdr/default.nix > /dev/null && echo OK`
+Expected: prints `OK` (syntax valid). Full evaluation is exercised in Task 4.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add modules/home/herdr/default.nix
+git commit -m "feat(herdr): add programs.herdr home-manager module"
+```
+
+---
+
+### Task 3: Wire the module into home.nix and remove the redundant package entry
+
+**Files:**
+- Modify: `users/jordangarrison/home.nix` (imports list ~line 27–30; herdr `home.packages` block at lines 234–236)
+
+- [ ] **Step 1: Add the module import**
+
+In `users/jordangarrison/home.nix`, in the `imports = [ ... ];` list (currently ending with `../../modules/home/pi`), add the herdr module:
+
+```nix
+  imports = [
+    ./tools/nvim/nvf.nix
+    ../../modules/home/acp-adapters
+    ../../modules/home/languages
+    ../../modules/home/pi
+    ../../modules/home/herdr
+  ];
+```
+
+- [ ] **Step 2: Enable and configure herdr near the other `programs.*` blocks**
+
+In `users/jordangarrison/home.nix`, immediately after the `programs.acp-adapters = { enable = true; };` block (around line 84–86), add:
+
+```nix
+  programs.herdr = {
+    enable = userApps.herdr.enable or false;
+    settings = {
+      onboarding = false;
+      theme.name = "rose-pine";
+      ui.agent_panel_scope = "all";
+      experimental.pane_history = true;
+      session.resume_agents_on_restore = true;
+    };
+  };
+```
+
+- [ ] **Step 3: Remove the now-redundant package entry**
+
+In `users/jordangarrison/home.nix`, delete the three-line herdr block at lines 234–236 (the module now installs the package). Remove exactly:
+
+```nix
+    ++ lib.optionals (userApps.herdr.enable or false) [
+      llm-agents.herdr
+    ]
+```
+
+Leave the surrounding `]` (line 233, end of the prior list) and the next `++ lib.optionals (userApps.todoist.enable or false) [` (was line 237) intact and directly adjacent.
+
+- [ ] **Step 4: Verify the whole NixOS config still evaluates and builds**
+
+Run: `nh os build . --no-nom`
+Expected: build succeeds with no evaluation errors. Confirm the herdr config derivation is present:
+
+Run: `nh os build . --no-nom 2>&1 | tail -20`
+Expected: ends in a successful build (no `error:` lines).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add users/jordangarrison/home.nix
+git commit -m "feat(herdr): manage config declaratively via programs.herdr"
+```
+
+---
+
+### Task 4: Apply and verify the generated config
+
+**Files:** none (runtime verification).
+
+- [ ] **Step 1: Apply to the running system**
+
+Run: `nh os test . --no-nom`
+Expected: activation succeeds.
+
+- [ ] **Step 2: Verify the managed config.toml exists and is correct**
+
+Run: `readlink -f ~/.config/herdr/config.toml`
+Expected: resolves to a `/nix/store/...-herdr-config.toml` path (proves it's Nix-managed / read-only).
+
+Run: `cat ~/.config/herdr/config.toml`
+Expected: contains exactly these settings (TOML key order may differ):
+
+```toml
+onboarding = false
+
+[experimental]
+pane_history = true
+
+[session]
+resume_agents_on_restore = true
+
+[theme]
+name = "rose-pine"
+
+[ui]
+agent_panel_scope = "all"
+```
+
+- [ ] **Step 3: Verify the handoff helper is on PATH**
+
+Run: `command -v herdr-handoff && herdr-handoff --help 2>&1 | head -3 || true`
+Expected: prints the `herdr-handoff` store path. (The script has no `--help`; it will attempt a handoff — so do NOT run it bare yet; just confirm it resolves on PATH.)
+
+- [ ] **Step 4: Reload config into the running server (best effort)**
+
+Run: `herdr server reload-config`
+Expected: succeeds. Note: `experimental.pane_history` is a startup-only setting and only takes effect after a server restart (see Task 5); `resume_agents_on_restore` is read at restore time. No commit needed for this task (no file changes).
+
+---
+
+### Task 5: Validate persistence behavior at runtime
+
+**Files:** none (runtime verification). These steps confirm the feature actually works; they involve restarting the herdr server, so run them when it's safe to do so.
+
+- [ ] **Step 1: Validate `pane_history` survives a restart**
+
+In a herdr session, leave some scrollback in a pane, then restart the server:
+
+Run: `herdr server stop` then `herdr` (reattach).
+Expected: `~/.config/herdr/session-history.json` now exists, and reopened panes replay recent scrollback.
+
+Run: `test -f ~/.config/herdr/session-history.json && echo "history persisted"`
+Expected: prints `history persisted`.
+
+- [ ] **Step 2: Validate agent session restore**
+
+Open a Claude Code pane in herdr, then restart the server (`herdr server stop`; `herdr`).
+Expected: the Claude Code pane resumes its prior conversation rather than starting empty. If it restores as a plain shell, check the integration version:
+
+Run: `herdr integration list 2>&1 | head -20`
+Expected: shows the Claude Code integration; note its version. Agent resume requires the Claude Code herdr integration "version 4" or newer. If older, record this as a follow-up (a herdr/integration bump) — it does not block parts 1–3.
+
+- [ ] **Step 3: Validate the handoff helper as a same-version no-op**
+
+This proves `server live-handoff --import-exe` works before relying on it across a real version bump. With a running herdr server:
+
+Run: `herdr server live-handoff --import-exe "$(readlink -f "$(which herdr)")"`
+Expected: handoff completes (`live handoff completed; old server exiting`) and the client reconnects with panes intact; or it cleanly reports an incompatible/again message. It must NOT leave the session broken. If it succeeds, `herdr-handoff` (the wrapper) is validated by extension.
+
+- [ ] **Step 4: No commit** (verification only).
+
+---
+
+### Task 6: Document the update workflow
+
+**Files:**
+- Modify: `CLAUDE.md` (add a short herdr persistence note) — repo root `nix-config/CLAUDE.md`.
+
+- [ ] **Step 1: Add a herdr persistence subsection**
+
+Append a concise note under a suitable section of `nix-config/CLAUDE.md` (e.g. near the development tooling notes). Add:
+
+```markdown
+### herdr session persistence
+
+herdr config is managed declaratively by `programs.herdr` (`modules/home/herdr/`),
+gated on `userApps.herdr.enable`. `config.toml` is a read-only Nix symlink — change
+settings in `users/jordangarrison/home.nix` and rebuild, not in the herdr UI.
+`pane_history` and `resume_agents_on_restore` are enabled, so scrollback and agent
+conversations survive a server restart (runtime state lives in the unmanaged
+`session.json` / `session-history.json`).
+
+**Update workflow (keep live processes across a herdr bump):**
+`herdr update --handoff` does not work on Nix (its downloader can't write to
+`/nix/store`). Instead:
+1. `nh flake update llm-agents` then `nh os switch . --no-nom`
+2. `herdr-handoff`  — migrates the running session onto the new store-path binary
+   via `herdr server live-handoff --import-exe`, keeping pane processes alive.
+If herdr refuses the handoff (incompatible protocol across versions), restart the
+server normally; `pane_history` + `resume_agents_on_restore` restore scrollback and
+agent conversations.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(herdr): document declarative config and live-handoff update workflow"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Spec §1 & §2 (enable `pane_history`, `resume_agents_on_restore`) → Task 3 Step 2 (settings), verified Task 4 Step 2 + Task 5 Steps 1–2. ✓
+- Spec §3 (declarative `programs.herdr` module, fold in existing settings, leave runtime state alone, drop redundant package entry) → Task 2 + Task 3. ✓
+- Spec §4 (`herdr-handoff` helper package via `mkScript` + overlay, installed by module) → Task 1 + module `home.packages` in Task 2, validated Task 5 Step 3. ✓
+- Spec testing/verification items → Tasks 4 and 5 (build, symlink inspection, reload-config, restart checks, integration version check, no-op handoff). ✓
+- Spec risk "integration version for agent resume" → Task 5 Step 2 records a follow-up. ✓
+- Spec out-of-scope items are not implemented. ✓
+- Docs note (update workflow) → Task 6 (beyond strict spec, but small and aids the user's stated goal). ✓
+
+**Placeholder scan:** No "TBD"/"TODO"/"handle edge cases". Every code step shows full file contents or the exact snippet and adjacency. ✓
+
+**Type/name consistency:** Option path `programs.herdr.{enable,package,settings}` is consistent across Tasks 2 and 3. `pkgs.herdr-handoff` defined in Task 1, referenced in Task 2 module. `tomlFormat.generate "herdr-config.toml"` name matches the expected `readlink` target shape in Task 4. ✓

--- a/docs/superpowers/specs/2026-05-28-herdr-session-persistence-design.md
+++ b/docs/superpowers/specs/2026-05-28-herdr-session-persistence-design.md
@@ -1,0 +1,196 @@
+# herdr session persistence — design
+
+**Date:** 2026-05-28
+**Status:** Approved (pending spec review)
+**Scope:** Make herdr survive walk-aways and version updates without losing session context, and manage its config declaratively in this repo.
+
+## Problem
+
+herdr is installed via Nix (`llm-agents.herdr`, v0.6.4) and enabled per-host through
+`userApps.herdr.enable` (endeavour, opportunity, and the work Darwin host). Its config at
+`~/.config/herdr/config.toml` is hand-edited and currently sets only `onboarding`, `theme`,
+and `ui.agent_panel_scope`. **None of herdr's persistence features are enabled.**
+
+herdr runs panes in a background server. On a server restart it restores only the session
+*shape* (workspaces, tabs, panes, working dirs, focus). By default it discards:
+
+- running processes / shells,
+- terminal scrollback contents,
+- agent conversations (Claude Code, Codex, etc.).
+
+The user's goal: *"walk away from my computer or update herdr and come back and jump right
+back in."* Today an update (or reboot) wipes everything but the layout.
+
+## Key constraint and the handoff finding
+
+herdr ships `herdr update --handoff`, which keeps live panes alive across a self-update. Its
+docs say package-manager installs (Homebrew, **Nix**) can't use it — because `herdr update`
+downloads and writes a new binary, which the immutable `/nix/store` forbids
+(`installed remote binary to ~/.local/bin/herdr`).
+
+**However**, direct inspection of the v0.6.4 binary shows the handoff is a *separable*
+subcommand, not bound to the downloader:
+
+```
+herdr server live-handoff [--import-exe <path>] [--expected-protocol <n>] [--expected-version <version>]
+```
+
+- `--import-exe <path>` lets the caller supply the new binary — no download step.
+- It transfers each pane's PTY master file descriptor to the new server over the unix socket
+  via `SCM_RIGHTS` (`handoff fd message missing SCM_RIGHTS`,
+  `struct HandoffPane { child_pid, … }`); **child processes are adopted, not restarted**
+  (`preserving pane runtime for handoff`).
+- It is version/protocol gated (`HandoffManifest { source_version, source_protocol,
+  expected_protocol }`; `live handoff was requested, but no compatible server responded`). A
+  herdr bump that crosses a protocol boundary will *refuse* the handoff and the user falls back
+  to a normal restart — safe degradation, not a crash.
+
+So on Nix the handoff is reachable by supplying the freshly-built store-path binary:
+
+```sh
+herdr server live-handoff --import-exe "$(readlink -f "$(which herdr)")"
+```
+
+The old server spawns the new store-path binary and hands off the live panes. Only the
+*download* step is Nix-hostile; the handoff itself is not.
+
+> Caveat: this is a manual invocation of an internal subcommand. Treat it as best-effort. It
+> has not been runtime-tested end-to-end; evidence is the binary's own usage strings and
+> symbols. Validate with a same-version no-op handoff before relying on it across a real bump.
+
+## Layered guarantee (what the user gets)
+
+| Scenario | Mechanism | What survives |
+|---|---|---|
+| Walk away (no restart) | `ctrl+b q` detach → reattach with `herdr` | **Everything** — processes, scrollback, agents |
+| Update herdr | `herdr-handoff` helper (part 4) | Live processes, layout, scrollback, agents — when protocol-compatible |
+| Reboot / crash / incompatible bump | snapshot restore + `pane_history` + `resume_agents_on_restore` | Layout, dirs, **scrollback**, **agent conversations** — *not* live processes |
+
+Live OS processes cannot survive a true restart on any install; that is unavoidable and
+out of scope.
+
+## Design
+
+Four parts. Parts 1–3 are the core; part 4 is the handoff helper.
+
+### 1 & 2. Enable the persistence knobs
+
+```toml
+[experimental]
+pane_history = true                 # scrollback survives a full restart
+
+[session]
+resume_agents_on_restore = true     # supported agents resume their native session
+```
+
+Accepted tradeoff: `pane_history` writes terminal contents (possibly secrets/tokens) to
+`~/.config/herdr/session-history.json` in plaintext. This is why herdr ships it off by
+default. The user has accepted this.
+
+### 3. Declarative config via a `programs.herdr` home module
+
+New module `modules/home/herdr/default.nix`, modeled on the existing `programs.tea` module.
+
+- Options: `programs.herdr.enable`, `programs.herdr.package` (default: the herdr package
+  currently referenced as `llm-agents.herdr` in `home.nix`), and `programs.herdr.settings`
+  (a TOML attrset via `pkgs.formats.toml { }`).
+- `config = mkIf cfg.enable { ... }` installs the package and writes
+  `xdg.configFile."herdr/config.toml"` from `settings`.
+- Default `settings` fold in the current hand-edited values plus the new knobs:
+
+  ```nix
+  settings = {
+    onboarding = false;
+    theme.name = "rose-pine";
+    ui.agent_panel_scope = "all";
+    experimental.pane_history = true;
+    session.resume_agents_on_restore = true;
+  };
+  ```
+
+Wiring:
+
+- Import `../../modules/home/herdr` from `users/jordangarrison/home.nix` (cross-platform —
+  the config path is `~/.config/herdr` on both Linux and Darwin).
+- Set `programs.herdr.enable = userApps.herdr.enable or false;` so the existing per-host
+  switch in `flake.nix` stays the single source of truth.
+- Remove the now-redundant `llm-agents.herdr` entry from the `home.packages` list in
+  `home.nix` (the module installs it instead). Keep the `userApps.herdr` option definition in
+  `nixos.nix` unchanged.
+
+Runtime state files (`session.json`, `session-history.json`, logs, sockets, `release-notes.json`)
+are **not** managed — they stay mutable in `~/.config/herdr`.
+
+Accepted tradeoff: a Nix-managed `config.toml` is a read-only symlink, so settings changed
+inside the herdr UI won't persist — all config changes go through the repo + rebuild, matching
+the model used for every other tool here. (herdr writes its mutable state to the separate files
+above, not to `config.toml`, so this does not break herdr's own bookkeeping.)
+
+### 4. `herdr-handoff` helper package
+
+A shell script packaged via `lib/mkScript.nix` and registered in `modules/scripts-overlay.nix`,
+matching the existing script-package convention (`myip`, `gi`, `ksn`, …).
+
+- `packages/herdr-handoff/herdr-handoff.sh`:
+
+  ```sh
+  #!/usr/bin/env bash
+  set -euo pipefail
+  new_exe="$(readlink -f "$(command -v herdr)")"
+  echo "herdr: handing off live panes to $new_exe"
+  exec herdr server live-handoff --import-exe "$new_exe"
+  ```
+
+- Register as `herdr-handoff` in `scripts-overlay.nix` (deps: `coreutils` for `readlink`;
+  herdr is already on PATH).
+- Add to the herdr module's installed packages (alongside `cfg.package`) so it ships wherever
+  herdr is enabled.
+
+Intended workflow: `nh flake update llm-agents` → `nh os switch . --no-nom` → then run
+`herdr-handoff` to migrate the running session onto the new binary with live processes intact.
+If the protocol gate refuses (incompatible bump), herdr aborts/rolls back and the user falls
+back to a normal restart, where parts 1–2 restore scrollback + agent conversations.
+
+## Components and boundaries
+
+- **`modules/home/herdr/default.nix`** — owns the `programs.herdr` option surface and writes
+  `config.toml`. Depends only on `pkgs.formats.toml` and the herdr package. Testable by
+  inspecting the generated symlink target.
+- **`packages/herdr-handoff/herdr-handoff.sh`** + overlay entry — one job: invoke
+  `server live-handoff` against the current store-path binary. Independent of the module.
+- **Wiring in `home.nix`** — maps the existing `userApps.herdr.enable` switch to
+  `programs.herdr.enable`. No new host-level option.
+
+## Testing / verification
+
+1. `nh os build . --no-nom`, then `nh os test . --no-nom` (opportunity and/or endeavour). Build
+   validates the module and TOML generation.
+2. Inspect the result: `cat ~/.config/herdr/config.toml` resolves to the Nix store and contains
+   the five settings.
+3. Apply without a full restart where possible: `herdr server reload-config`. Note startup-only
+   settings (likely `pane_history`) require a server restart to take effect — verify by
+   restarting the server and confirming `session-history.json` appears and scrollback replays.
+4. Confirm `resume_agents_on_restore` by restarting the server with a Claude Code pane open and
+   checking the conversation resumes.
+5. Validate the handoff helper as a **same-version no-op** first:
+   `herdr server live-handoff --import-exe "$(readlink -f "$(which herdr)")"` on a throwaway
+   session — confirms the path/flags work before trusting it across a real bump.
+
+## Risks
+
+- **Read-only config** breaks in-UI settings changes. Mitigated: all config goes through the
+  repo; herdr's mutable state lives in separate files.
+- **Secrets in `session-history.json`** (accepted).
+- **Handoff is an unsupported manual path** — may refuse across protocol-incompatible herdr
+  versions, and a failed commit window exists (`handoff replacement server was ready, but commit
+  failed`). Mitigated by version gating + rollback, and by falling back to restart + parts 1–2.
+- **herdr integration version for agent resume** — Claude Code needs integration "version 4"+.
+  Verify with `herdr integration` subcommands during implementation; note if a bump is needed.
+
+## Out of scope
+
+- Keeping live OS processes alive across a true restart/reboot (impossible without handoff, and
+  handoff only covers the binary-swap case).
+- Remote/SSH handoff (`herdr --remote … --handoff`) — supported by the binary but not part of
+  this local-persistence goal.
+- Replacing the `herdr update` self-updater; updates continue to flow through the Nix flake.

--- a/modules/home/herdr/default.nix
+++ b/modules/home/herdr/default.nix
@@ -1,0 +1,58 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+
+let
+  cfg = config.programs.herdr;
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  options.programs.herdr = {
+    enable = mkEnableOption "herdr terminal workspace manager for AI coding agents";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.llm-agents.herdr;
+      defaultText = literalExpression "pkgs.llm-agents.herdr";
+      description = "The herdr package to install.";
+    };
+
+    settings = mkOption {
+      type = tomlFormat.type;
+      default = { };
+      example = literalExpression ''
+        {
+          onboarding = false;
+          theme.name = "rose-pine";
+          experimental.pane_history = true;
+          session.resume_agents_on_restore = true;
+        }
+      '';
+      description = ''
+        Settings written to {file}`$XDG_CONFIG_HOME/herdr/config.toml`.
+
+        Because Nix manages this file it becomes a read-only symlink: change
+        settings here and rebuild rather than editing them in the herdr UI.
+        herdr's mutable runtime state (session.json, session-history.json,
+        logs, sockets, release-notes.json) is intentionally not managed and
+        stays writable.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [
+      cfg.package
+      pkgs.herdr-handoff
+    ];
+
+    xdg.configFile."herdr/config.toml" = mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "herdr-config.toml" cfg.settings;
+    };
+  };
+}

--- a/modules/home/herdr/default.nix
+++ b/modules/home/herdr/default.nix
@@ -43,6 +43,40 @@ in
         stays writable.
       '';
     };
+
+    integrations = mkOption {
+      type = types.listOf (types.enum [
+        "pi"
+        "omp"
+        "claude"
+        "codex"
+        "opencode"
+        "hermes"
+        "qodercli"
+      ]);
+      default = [ ];
+      example = [
+        "claude"
+        "codex"
+      ];
+      description = ''
+        herdr agent integrations to install and keep current on every
+        activation, via `herdr integration install <name>`.
+
+        herdr installs these hooks into per-agent dotfiles (e.g.
+        {file}`~/.claude/hooks/herdr-agent-state.sh`) and bumps their version
+        with each herdr release. The hooks record the agent's native session
+        id, which is what `session.resume_agents_on_restore` needs to resume a
+        conversation after a server restart. Re-running the installer on every
+        rebuild keeps the hooks in sync with the installed herdr version, so
+        agent-session resume keeps working across herdr updates instead of
+        silently breaking when the integration version drifts.
+
+        These hooks live in mutable dotfiles outside the Nix store (that is how
+        herdr ships them); this option only keeps them current, it does not
+        manage their contents declaratively.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -54,5 +88,17 @@ in
     xdg.configFile."herdr/config.toml" = mkIf (cfg.settings != { }) {
       source = tomlFormat.generate "herdr-config.toml" cfg.settings;
     };
+
+    # Keep the agent integration hooks in sync with the installed herdr
+    # version on every activation. Install is idempotent and writes only to
+    # per-agent dotfiles; a failure is non-fatal so it never aborts a switch.
+    home.activation.herdrIntegrations = mkIf (cfg.integrations != [ ]) (
+      hm.dag.entryAfter [ "writeBoundary" ] (
+        concatMapStringsSep "\n" (agent: ''
+          run ${cfg.package}/bin/herdr integration install ${agent} \
+            || echo "herdr: 'integration install ${agent}' failed (non-fatal)" >&2
+        '') cfg.integrations
+      )
+    );
   };
 }

--- a/modules/scripts-overlay.nix
+++ b/modules/scripts-overlay.nix
@@ -47,6 +47,13 @@
         deps = with final; [ flarectl ];
         description = "Cloudflare CLI with automatic API token from ACME secrets";
       };
+
+      herdr-handoff = mkScript {
+        name = "herdr-handoff";
+        script = ../packages/herdr-handoff/herdr-handoff.sh;
+        deps = with final; [ coreutils ];
+        description = "Migrate the running herdr session onto the current binary via live-handoff";
+      };
     })
   ];
 }

--- a/packages/herdr-handoff/herdr-handoff.sh
+++ b/packages/herdr-handoff/herdr-handoff.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# herdr-handoff — migrate the running herdr session onto the current binary,
+# keeping live pane processes alive. The Nix-viable alternative to
+# `herdr update --handoff` (whose downloader can't write to /nix/store).
+#
+# Usage: after `nh os switch`, run `herdr-handoff` to hand the running
+# server's live panes to the freshly-built herdr binary.
+set -euo pipefail
+
+new_exe="$(readlink -f "$(command -v herdr)")"
+echo "herdr-handoff: handing off live panes to ${new_exe}"
+echo "herdr-handoff: if the protocol is incompatible, herdr will refuse and you should restart instead."
+exec herdr server live-handoff --import-exe "${new_exe}"

--- a/users/jordangarrison/home.nix
+++ b/users/jordangarrison/home.nix
@@ -27,6 +27,7 @@ in
     ../../modules/home/acp-adapters
     ../../modules/home/languages
     ../../modules/home/pi
+    ../../modules/home/herdr
   ];
 
   languages = {
@@ -83,6 +84,17 @@ in
 
   programs.acp-adapters = {
     enable = true;
+  };
+
+  programs.herdr = {
+    enable = userApps.herdr.enable or false;
+    settings = {
+      onboarding = false;
+      theme.name = "rose-pine";
+      ui.agent_panel_scope = "all";
+      experimental.pane_history = true;
+      session.resume_agents_on_restore = true;
+    };
   };
 
   home.packages =
@@ -230,9 +242,6 @@ in
     ]
     ++ lib.optionals (userApps.handy.enable or false) [
       llm-agents.handy
-    ]
-    ++ lib.optionals (userApps.herdr.enable or false) [
-      llm-agents.herdr
     ]
     ++ lib.optionals (userApps.todoist.enable or false) [
       todoist

--- a/users/jordangarrison/home.nix
+++ b/users/jordangarrison/home.nix
@@ -88,6 +88,12 @@ in
 
   programs.herdr = {
     enable = userApps.herdr.enable or false;
+    integrations = [
+      "claude"
+      "codex"
+      "pi"
+      "opencode"
+    ];
     settings = {
       onboarding = false;
       theme.name = "rose-pine";


### PR DESCRIPTION
## Summary

Make herdr survive walk-aways and version updates without losing session context, managed declaratively in this repo.

- **`programs.herdr` home module** (`modules/home/herdr/`, modeled on `programs.tea`) writes `~/.config/herdr/config.toml` from a TOML settings attrset and installs herdr. Gated on the existing `userApps.herdr.enable` switch.
- **Persistence knobs enabled:** `experimental.pane_history` (scrollback survives a restart) and `session.resume_agents_on_restore` (agent conversations resume). Keys verified against `herdr --default-config`.
- **`herdr-handoff` helper package** wraps `herdr server live-handoff --import-exe "$(readlink -f "$(which herdr)")"` — the Nix-viable path to keep **live pane processes** alive across a herdr bump. (`herdr update --handoff` can't work on Nix: its downloader can't write to `/nix/store`. The handoff itself is a separable socket fd-transfer, so supplying the freshly-built store-path binary works.)
- **`programs.herdr.integrations`** re-runs `herdr integration install <agent>` on every activation for `["claude" "codex" "pi" "opencode"]`. This fixes the root cause of resume silently breaking: the per-agent hooks (`~/.claude/hooks/...`) drift in version on every herdr release.
- Spec + plan under `docs/superpowers/`, workflow docs in `AGENTS.md`.

## Test Plan

- [x] `nh os build . --no-nom` passes
- [x] `nh os test . --no-nom` applies cleanly (no server restart); `config.toml` resolves to a read-only Nix store symlink with the five expected keys
- [x] `herdr server reload-config` → `"status":"applied"` with empty diagnostics (all keys recognized)
- [x] `herdr-handoff` on PATH; activation script contains the four `integration install` calls
- [x] `herdr integration status` → claude/codex v4, pi/opencode v2 (all current) after activation
- [x] Full scrollback replay + agent-conversation resume — validates organically on the next reboot/herdr update (not tested live to avoid bouncing the active session)

Notes / caveats (documented in AGENTS.md):
- `pane_history` is startup-only — the first restart after enabling captures nothing; the next begins capturing.
- Live-handoff is an unsupported manual invocation; it's version/protocol-gated and degrades to a normal restart on incompatible bumps.
- The Nix-managed `config.toml` is a read-only symlink — change settings in `home.nix` and rebuild, not in the herdr UI.